### PR TITLE
Fix runUtilResp (BREAKS PROOFS!!!)

### DIFF
--- a/cava/Cava/Util/List.v
+++ b/cava/Cava/Util/List.v
@@ -1027,6 +1027,15 @@ Section Replace.
       | S n' => x :: replace n' a xs
       end
     end%list.
+
+  Lemma length_replace {A} : forall n a (ls: list A),
+      length (replace n a ls) = length ls.
+  Proof.
+    intros. generalize dependent n.
+    induction ls; intros; destruct n;
+      try reflexivity;
+      cbn; auto.
+  Qed.
 End Replace.
 
 (* Proofs about fold_right and fold_left *)

--- a/cava2/TLUL.v
+++ b/cava2/TLUL.v
@@ -650,4 +650,51 @@ Section TLULSpec.
     Global Instance tlul_adapter_reg_correctness : correctness_for tlul_adapter_reg.
     Proof. constructor; typeclasses eauto. Defined.
 
+
+
+    Lemma outstanding_in_repr : forall r_tlul t,
+        outstanding_h2d r_tlul = Some t ->
+        In t r_tlul.
+    Proof.
+      intros ? ?.
+      induction r_tlul; intros Houts; cbn in Houts.
+      - discriminate.
+      - destruct (outstanding_h2d r_tlul) eqn:Houts'.
+        + destruct d_ready.
+          * discriminate.
+          * apply in_cons. auto.
+        + destruct (a_valid a).
+          * inversion Houts. apply in_eq.
+          * discriminate.
+    Qed.
+
+    Lemma outstanding_a_valid : forall r_tlul t,
+        outstanding_h2d r_tlul = Some t ->
+        a_valid t = true.
+    Proof.
+      intros ? ?.
+      induction r_tlul; intros Houts; cbn in Houts.
+      - discriminate.
+      - destruct (outstanding_h2d r_tlul) eqn:Houts'.
+        + destruct d_ready.
+          * discriminate.
+          * auto.
+        + destruct (a_valid a) eqn:Hvalid.
+          * inversion Houts. subst. assumption.
+          * discriminate.
+    Qed.
+
+    Lemma outstanding_prec : forall tl_st r_tlul t,
+        tlul_invariant tl_st r_tlul ->
+        outstanding_h2d r_tlul = Some t ->
+        a_opcode t = Get \/ a_opcode t = PutFullData.
+    Proof.
+      intros ? ? ? Hinvar Houts. simpl in *.
+      apply outstanding_in_repr in Houts as Hin.
+      unfold tlul_invariant in Hinvar. logical_simplify.
+      eapply Forall_forall in H. 2: apply Hin.
+      apply H.
+      eapply outstanding_a_valid.
+      apply Houts.
+    Qed.
 End TLULSpec.

--- a/cava2/TLUL.v
+++ b/cava2/TLUL.v
@@ -419,8 +419,8 @@ Section TLULSpec.
                        | None => if a_valid h2d then
                                   io_re = true
                                   /\ io_address = a_address h2d
-                                else True
-                       | _ => True
+                                else io_re = false
+                       | _ => io_re = false
                        end
                      /\ io_we = false
                    else if a_opcode h2d' =? PutFullData then
@@ -440,8 +440,8 @@ Section TLULSpec.
                                        /\ io_address = a_address h2d
                                        /\ io_data = a_data h2d
                                        /\ io_mask = a_mask h2d
-                                     else True
-                            | _ => True
+                                     else io_we = false
+                            | _ => io_we = false
                             end
                         else True
                  end
@@ -449,7 +449,10 @@ Section TLULSpec.
 
   Global Instance tlul_invariant : invariant_for (tlul_adapter_reg (reg_count:=reg_count)) tlul_repr :=
     fun (state : denote_type (state_of tlul_adapter_reg)) repr =>
-      tlul_adapter_reg_state_error state = false
+      Forall (fun h2d => (a_valid h2d = true
+                       -> (a_opcode h2d = Get \/ a_opcode h2d = PutFullData)))
+             repr
+      /\ tlul_adapter_reg_state_error state = false
       /\ match outstanding_h2d repr with
         | None =>
           tlul_adapter_reg_state_outstanding (reg_count:=reg_count) state = false
@@ -491,7 +494,8 @@ Section TLULSpec.
       end.
       repeat (destruct_pair_let; cbn [fst snd]).
       tlul_adapter_reg_state_simpl.
-      split.
+      ssplit.
+      - apply Forall_cons; assumption.
       - destruct (a_valid0 && negb outstanding)%bool; subst; reflexivity.
       - remember (outstanding_h2d
                     ((a_valid0,
@@ -537,7 +541,7 @@ Section TLULSpec.
                    destruct d_ready0.
                    --- reflexivity.
                    --- discriminate Eouts.
-                ** inversion H2.
+                ** exfalso. assumption.
           -- destruct a_valid0.
              +++ discriminate Eouts.
              +++ boolsimpl. reflexivity.
@@ -583,35 +587,35 @@ Section TLULSpec.
                cbn -[N.ones]. split. 1: reflexivity.
                subst. rewrite <- Eouts'. rewrite Hget, Hput. tlsimpl.
                ssplit; reflexivity.
-            -- inversion H1.
-        + destruct a_valid0; try discriminate H0.
-          inversion H0; subst. clear H0.
+            -- exfalso. assumption.
+        + destruct a_valid0; try discriminate H1.
+          inversion H1; subst. clear H1.
           do 8 eexists. split. 1: reflexivity.
           cbn -[N.ones]. split. 1: reflexivity.
           subst. rewrite <- Eouts'. tlsimpl.
-          destruct H2.
+          destruct H3.
           * reflexivity.
-          * rewrite H. boolsimpl. cbn -[N.ones].
+          * subst. boolsimpl. cbn -[N.ones].
             ssplit; try reflexivity.
             rewrite N.land_ones.
             replace 4 with (2 ^ 2) by reflexivity.
             rewrite <- ! N.shiftr_div_pow2.
             reflexivity.
-          * rewrite H. boolsimpl. cbn. ssplit; reflexivity.
-        + destruct a_valid0; try discriminate H0.
-          inversion H0; subst. clear H0.
+          * subst. boolsimpl. cbn. ssplit; reflexivity.
+        + destruct a_valid0; try discriminate H1.
+          inversion H1; subst. clear H1.
           do 8 eexists. split. 1: reflexivity.
           cbn -[N.ones]. split. 1: reflexivity.
           subst. rewrite <- Eouts'. tlsimpl.
-          destruct H2.
+          destruct H3.
           * reflexivity.
-          * rewrite H. boolsimpl. cbn -[N.ones].
+          * subst. boolsimpl. cbn -[N.ones].
             ssplit; try reflexivity.
             rewrite N.land_ones.
             replace 4 with (2 ^ 2) by reflexivity.
             rewrite <- ! N.shiftr_div_pow2.
             reflexivity.
-          * rewrite H. boolsimpl. cbn. ssplit; reflexivity.
+          * subst. boolsimpl. cbn. ssplit; reflexivity.
       - simpl in Eouts.
         remember (outstanding_h2d repr) as outs' eqn:Eouts'.
         destruct outs'; subst;
@@ -626,15 +630,15 @@ Section TLULSpec.
                cbn -[N.ones]. split. 1: reflexivity.
                subst. rewrite <- Eouts'. tlsimpl.
                ssplit; reflexivity.
-            -- inversion H1.
-        + destruct a_valid0; try discriminate H0.
-          clear H0.
+            -- exfalso. assumption.
+        + destruct a_valid0; try discriminate H1.
+          clear H1.
           do 8 eexists. split. 1: reflexivity.
           cbn -[N.ones]. split. 1: reflexivity.
           subst. rewrite <- Eouts'. tlsimpl.
           ssplit; reflexivity.
-        + destruct a_valid0; try discriminate H0.
-          clear H0.
+        + destruct a_valid0; try discriminate H1.
+          clear H1.
           do 8 eexists. split. 1: reflexivity.
           cbn -[N.ones]. split. 1: reflexivity.
           subst. rewrite <- Eouts'. tlsimpl.

--- a/firmware/IncrementWait/CavaIncrementDevice.v
+++ b/firmware/IncrementWait/CavaIncrementDevice.v
@@ -51,20 +51,22 @@ Section WithParameters.
 
   Global Instance counter_device: device := {|
     device.state := denote_type (state_of incr);
-    device.is_ready_state s := exists r_prev_state r_regs r_inner,
-        incr_invariant s (RSIdle, r_prev_state, r_regs, TLUL.Idle, r_inner);
+
+    device.is_ready_state s := exists r_regs r_tl r_inner,
+        incr_invariant s (RSIdle, r_regs, r_tl, r_inner);
+
     device.last_d2h '((_, (_, (_, d2h))), _) := d2h;
+
     device.tl_inflight_ops '((_, (_, (_, d2h))), _) :=
       if d_valid d2h then [d_source d2h] else [];
+
     device.run1 s i := fst (Semantics.step incr s (i, tt));
+
     device.addr_range_start := INCR_BASE_ADDR;
     device.addr_range_pastend := INCR_END_ADDR;
+
     device.maxRespDelay '((_, (_, (_, d2h))), _) :=
-      if a_ready d2h then 2
-      else if d_valid d2h then 1
-           else 0;
-    (* The last [else] is not reachable, because [d_valid] is always the
-       negation of [a_ready]. *)
+      if a_ready d2h then 0 else 1;
   |}.
 
   (* conservative upper bound matching the instance given in IncrementWaitToRiscv *)
@@ -72,58 +74,25 @@ Section WithParameters.
   {| ncycles_processing := 15%nat |}.
 
 
-  Inductive counter_related_base: IncrementWaitSemantics.state -> Incr.repr_state -> Incr.inner_state -> Prop :=
-  | IDLE_related: forall r_innr,
-      counter_related_base IDLE RSIdle r_innr
-  | BUSY1_related: forall val ncycles,
-      (1 < ncycles)%nat ->
-      counter_related_base (BUSY val ncycles) (RSBusy (word_to_N val))
-                           (IISBusy (word_to_N val) 1)
-  | BUSY2_related: forall val ncycles,
-      (0 < ncycles)%nat ->
-      counter_related_base (BUSY val ncycles) (RSBusy (word_to_N val))
-                           (IISBusy (word_to_N val) 2)
+  Inductive counter_related_spec: IncrementWaitSemantics.state -> Incr.repr_state -> Prop :=
+  | IDLE_related: counter_related_spec IDLE RSIdle
+  | BUSY_related: forall val ncycles count,
+      (0 < count <= 2)%nat ->
+      (2 < ncycles + count)%nat ->
+      counter_related_spec (BUSY val ncycles) (RSBusy (word_to_N val) count)
   (* the hardware is already done, but the software hasn't polled it yet to find out,
      so we have to relate a software-BUSY to a hardware-done: *)
-  | BUSY_done_related: forall val ncycles r_innr,
-      counter_related_base (BUSY val ncycles) (RSDone (word_to_N (word.add (word.of_Z 1) val))) r_innr
-  | DONE_related: forall val r_innr,
-      counter_related_base (DONE val) (RSDone (word_to_N val)) r_innr.
-
-  Inductive counter_related_spec: IncrementWaitSemantics.state -> repr ->
-                                  list tl_h2d -> Prop :=
-  | No_inflight: forall sH r_state r_prev_state r_regs r_inner,
-      counter_related_base sH r_state r_inner ->
-      counter_related_spec sH (r_state, r_prev_state, r_regs, TLUL.Idle, r_inner) []
-  | Inflight_read_status: forall sH r_state r_prev_state r_regs r_tl r_tl_regs r_inner h2d,
-      counter_related_base sH r_state r_inner ->
-      r_tl = TLUL.OutstandingAccessAckData (set_a_address 4 h2d) r_tl_regs ->
-      a_valid h2d = true ->
-      a_opcode h2d = Get ->
-      a_address h2d = word_to_N (state_machine.reg_addr STATUS) ->
-      counter_related_spec sH (r_state, r_prev_state, r_regs, r_tl, r_inner) [h2d]
-  | Inflight_read_value: forall r_prev_state r_regs r_tl r_tl_regs r_inner val h2d,
-      r_tl = TLUL.OutstandingAccessAckData (set_a_address 0 h2d) r_tl_regs ->
-      nth 0 r_tl_regs 0%N = word_to_N val ->
-      a_valid h2d = true ->
-      a_opcode h2d = Get ->
-      a_address h2d = word_to_N (state_machine.reg_addr VALUE) ->
-      counter_related_spec (DONE val)
-                           (RSIdle, r_prev_state, r_regs, r_tl, r_inner)
-                           [h2d]
-  | Inflight_write_value: forall r_prev_state r_regs r_tl r_inner val h2d,
-      r_tl = TLUL.OutstandingAccessAck (set_a_address 0 h2d) ->
-      a_valid h2d = true ->
-      a_opcode h2d = PutFullData ->
-      a_address h2d = word_to_N (state_machine.reg_addr VALUE) ->
-      a_data h2d = (word_to_N val) ->
-      counter_related_spec (IDLE)
-                           (RSBusy (word_to_N val), r_prev_state, r_regs, r_tl, r_inner)
-                           [h2d].
+  | BUSY_done_related: forall val ncycles,
+      counter_related_spec (BUSY val ncycles) (RSDone (word_to_N (word.add (word.of_Z 1) val)))
+  | DONE_related: forall val,
+      counter_related_spec (DONE val) (RSDone (word_to_N val)).
 
   Definition counter_related {invariant : invariant_for incr repr} (sH : IncrementWaitSemantics.state)
              (sL : denote_type (state_of incr)) (inflight_h2ds : list tl_h2d) : Prop :=
-    exists repr, counter_related_spec sH repr inflight_h2ds /\ invariant sL repr.
+    exists r_state r_regs r_tl r_inner,
+      inflight_h2ds = [] /\
+      counter_related_spec sH r_state /\
+      invariant sL (r_state, r_regs, r_tl, r_inner).
 
   (* This should be in bedrock2.ZnWords. It is use by ZnWords, which is used in
      the two following Lemmas. *)
@@ -137,62 +106,8 @@ Section WithParameters.
       (0 <= x < 2 ^ 32)%Z -> word_to_N (word.of_Z x) = Z.to_N x.
   Proof. intros. unfold word_to_N. ZnWords. Qed.
 
-  Set Printing Depth 100000.
-
-  Ltac destruct_pair_let_hyp :=
-    match goal with
-    | H: context [ match ?p with
-                   | pair _ _ => _
-                   end ] |- _ =>
-      destruct p as [?p0 ?p1] eqn:?H0
-    end.
-
-  Ltac destruct_pair_equal_hyp :=
-    match goal with
-    | H: context [ (?l0, ?l1) = (?r0, ?r1) ] |- _ =>
-      eapply pair_equal_spec in H; destruct H as [?H0 ?H1]
-    end.
-
   Lemma N_to_word_word_to_N: forall v, N_to_word (word_to_N v) = v.
   Proof. intros. unfold N_to_word, word_to_N. ZnWords. Qed.
-
-(* TODO move to coqutil *)
-Ltac contradictory H :=
-  lazymatch type of H with
-  | ?x <> ?x => exfalso; apply (H eq_refl)
-  | False => case H
-  end.
-
-Require Import coqutil.Tactics.autoforward.
-
-Ltac fwd_step ::=
-  match goal with
-  | H: ?T |- _ => is_destructible_and T; destr_and H
-  | H: exists y, _ |- _ => let yf := fresh y in destruct H as [yf H]
-  | H: ?x = ?x |- _ => clear H
-  | H: True |- _ => clear H
-  | H: ?LHS = ?RHS |- _ =>
-    let h1 := head_of_app LHS in is_constructor h1;
-    let h2 := head_of_app RHS in is_constructor h2;
-    (* if not eq, H is a contradiction, but we don't want to change the number
-       of open goals in this tactic *)
-    constr_eq h1 h2;
-    (* we don't use `inversion H` or `injection H` because they unfold definitions *)
-    inv_rec LHS RHS;
-    clear H
-  | E: ?x = ?RHS |- context[match ?x with _ => _ end] =>
-    let h := head_of_app RHS in is_constructor h; rewrite E in *
-  | H: context[match ?x with _ => _ end], E: ?x = ?RHS |- _ =>
-    let h := head_of_app RHS in is_constructor h; rewrite E in *
-  | H: context[match ?x with _ => _ end] |- _ =>
-    (* note: recursive invocation of fwd_step for contradictory cases *)
-    destr x; try solve [repeat fwd_step; contradictory H]; []
-  | H: _ |- _ => autoforward with typeclass_instances in H
-  | |- _ => progress subst
-  | |- _ => progress fwd_rewrites
-  end.
-
-  Axiom TODO: False.
 
   Ltac use_spec :=
     match goal with
@@ -200,33 +115,54 @@ Ltac fwd_step ::=
             Hinv: incr_invariant ?sL ?repr
       |- _ =>
       assert (Hprec: precondition incr (input, tt) repr);
-      [|
-       (* pose proof (output_correct_pf (c:=incr) (input, tt) sL repr Hinv Hprec) as Hpostc. *)
-       remember (update_repr (c:=incr) (input, tt) repr) as repr' eqn:Erepr';
-       pose proof (invariant_preserved_pf (c:=incr) (input, tt) sL repr repr' Erepr' Hinv Hprec) as Hinv';
-       unfold device.run1, counter_device in Hrun;
-       match type of Hrun with
-       | fst ?step = _ =>
-         remember step as res eqn:Hstep;
-         destruct res as (?sL'' & ?d2h);
-         cbn in Hrun; subst sL''; clear Hstep
-       end;
-       cbn [fst] in Hinv']
+      [ simplify_spec (incr (var:=var)); simplify_spec (tlul_adapter_reg (reg_count:=2)); simplify_spec (Incr.inner (var:=var));
+        simplify_invariant (incr (var:=var));
+        cbn in sL; destruct sL as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner));
+        destruct_tl_h2d; tlsimpl; logical_simplify; subst;
+        ssplit; intros; try discriminate; auto
+
+      | remember (update_repr (c:=incr) (input, tt) repr) as repr' eqn:Erepr';
+        (* pose proof (output_correct_pf (c:=incr) (input, tt) sL repr Hinv Hprec) as Hpostc. *)
+        pose proof (invariant_preserved_pf (c:=incr) (input, tt) sL repr repr' Erepr' Hinv Hprec) as Hinv';
+        unfold device.run1, counter_device in Hrun;
+        match type of Hrun with
+        | fst ?step = _ =>
+          remember step as res eqn:Hstep;
+          destruct res as (?sL'' & ?d2h);
+          cbn in Hrun; subst sL''; clear Hstep
+        end;
+        cbn [fst] in Hinv';
+        destruct repr' as (((?r_state, ?r_regs), ?r_tl), ?r_inner)]
     end.
 
   Ltac inversion_rel_spec :=
     match goal with
-    | H: counter_related_spec _ _ _ |- _ => inversion H; subst
-    end.
-  Ltac inversion_rel_base :=
-    match goal with
-    | H: counter_related_base _ _ _ |- _ => inversion H; subst
+    | H: counter_related_spec _ _ |- _ => inversion H; subst
     end.
 
-  (* Lemma output_last_d2h : forall s h2d s' d2h, *)
-  (*     (s', d2h) = Semantics.step incr s (h2d, tt) -> *)
-  (*     device.last_d2h s' = d2h. *)
-  (* Proof. *)
+  Ltac simplify_tl_repr :=
+    unfold device.maxRespDelay, device.last_d2h, counter_device in *;
+    repeat match goal with
+    | sL: device.state |- _ =>
+      cbn in sL; destruct sL as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner))
+    end;
+    destruct_tl_h2d; destruct_tl_d2h; tlsimpl; logical_simplify; subst;
+    simplify_invariant (incr (var:=var));
+    match goal with
+    | H: _ = update_repr _ (_, _, ?r_tl, _) |- _ =>
+      destruct r_tl; logical_simplify; tlsimpl; subst;
+      (* logical_simplify; subst; *)
+      cbn in H; rewrite ? Z_word_N in H by lia; cbn in H
+    end;
+    logical_simplify; subst;
+    cbn; rewrite ? Z_word_N by lia; cbn;
+    change (Pos.to_nat 1) with 1;
+    repeat match goal with
+    | H: length ?regs = 2 |- _ =>
+      destruct regs as [|? [|? [|]]]; cbn in H; try discriminate H; clear H;
+      cbn [nth] in *; subst
+    end;
+    try discriminate.
 
   Global Instance cava_counter_satisfies_state_machine:
     device_implements_state_machine counter_device increment_wait_state_machine.
@@ -235,323 +171,136 @@ Ltac fwd_step ::=
     - (* mmioAddrs_match: *)
       reflexivity.
     - (* initial_state_is_ready_state: *)
-      intros ? ? ? Hrel.
-      cbn in *. subst. destruct Hrel as [?repr [?Hrel ?Hinv]].
-      inversion_rel_spec. inversion_rel_base.
-      repeat eexists. eapply Hinv.
+      intros.
+      unfold device.is_ready_state, counter_device, counter_related in *;
+        logical_simplify.
+      cbn in *; subst.
+      inversion_rel_spec; repeat eexists; eassumption.
     - (* initial_states_are_related: *)
-      intros ? ? ? Hready.
-      cbn in *. destruct Hready as (?r_prev_state & ?r_regs & ?r_inner & ?Hinv). subst.
-      unfold counter_related. eexists. split; [|apply Hinv].
-      apply No_inflight, IDLE_related.
+      intros.
+      cbn in *; logical_simplify; subst.
+      unfold counter_related; repeat eexists; [|eassumption].
+      apply IDLE_related.
     - (* initial_state_exists: *)
-      intros ? Hready.
-      cbn in *. destruct Hready as (?r_prev_state & ?r_regs & ?r_inner & ?Hinv).
-      eexists. split; [reflexivity|].
-      unfold counter_related. eexists. split; [|apply Hinv].
-      apply No_inflight, IDLE_related.
+      intros.
+      cbn in *; logical_simplify; subst.
+      unfold counter_related; repeat eexists; [|eassumption].
+      apply IDLE_related.
     - (* nonMMIO_device_step_preserves_state_machine_state: *)
-      intros ? ? ? ? Ha_valid [repr [Hrel Hinv]] **.
-      use_spec.
-      { destruct_tl_h2d. destruct_tl_d2h. tlsimpl.
-        cbn in sL1; destruct sL1 as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner)).
-        destruct repr as ((((?r_state, ?r_prev_state), ?r_regs), ?r_tl), ?r_inner).
-        simplify_invariant incr. logical_simplify.
-        subst. cbn. ssplit; intros; [auto|discriminate|auto].
-      }
-      exists repr'; split; [|auto].
-      inversion_rel_spec; inversion_rel_base;
-        destruct_tl_h2d; destruct_tl_d2h; tlsimpl; subst;
-          cbn in sL1; destruct sL1 as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner));
-            simplify_invariant incr; logical_simplify; subst; cbn -[replace];
-              apply No_inflight; try (constructor; lia); [].
-      replace ((word_to_N val + 1) mod 4294967296)%N with
-          (word_to_N (word.add (word.of_Z 1) val)) by
-          (unfold word_to_N; ZnWords);
-        apply BUSY_done_related.
+      intros.
+      logical_simplify.
+      unfold counter_related in *; logical_simplify.
+      use_spec. clear Hprec.
+      repeat eexists; [|eassumption].
+      inversion_rel_spec; simplify_tl_repr;
+        destruct d_ready; logical_simplify; subst; try constructor;
+          (destruct count as [|[|[|]]]; [exfalso; lia|..|exfalso; lia]);
+          rewrite ? incrN_word_to_bv; constructor; lia.
 
     - (* [state_machine_read_to_device_send_read_or_later] *)
-      intros ? ? ? ? ? ? [v [sH'' Hex_read]] [repr [Hrel Hinv]] **.
-      cbn in Hex_read. logical_simplify.
-      rewrite H5. clear H5.
-      use_spec.
-      1: simplify_spec incr; simplify_spec (tlul_adapter_reg (reg_count:=2)); simplify_spec Incr.inner;
-        simplify_invariant incr;
-        cbn in sL; destruct sL as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner));
-          destruct repr as ((((?r_state, ?r_prev_state), ?r_regs), ?r_tl), ?r_inner);
-          destruct_tl_h2d; tlsimpl; logical_simplify; subst;
-            ssplit; intros; auto.
+      intros ? ? ? ? ? ? [v [sH'' [Hpow2 Hex_read]]] **.
+      rewrite Hpow2. clear Hpow2.
+      unfold counter_related in *. cbn in Hex_read. logical_simplify.
+      use_spec. clear Hprec.
 
       destruct_one_match; [destruct_one_match|].
-      (* case 1: device ready, valid response
-           In our TL implementation [a_ready = negb d_valid], hence this case
-           is not possible.
-           case 3: device not ready
-           If the inflight queue is empty, the device must be ready, hence
-           this case is not possible. *)
-      1,3: exfalso;
-        unfold device.last_d2h, counter_device in *;
-        cbn in sL; destruct sL as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner));
-          destruct repr as ((((?r_state, ?r_prev_state), ?r_regs), ?r_tl), ?r_inner);
-          simplify_invariant incr; subst; logical_simplify; destruct_tl_d2h; tlsimpl; subst;
-          inversion_rel_spec; logical_simplify; discriminate.
-      (* device ready, no valid response: *)
-      ssplit.
-      1: eexists; split; [|eassumption]; [].
-      all:
-        unfold device.tl_inflight_ops, device.last_d2h, device.maxRespDelay,
-        counter_device, counter_related in *;
-        cbn in sL; destruct sL as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner));
-          cbn in sL'; destruct sL' as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner));
-            destruct repr as ((((?r_state, ?r_prev_state), ?r_regs), ?r_tl), ?r_inner);
-            destruct_tl_d2h; destruct_tl_h2d;
-              simplify_spec incr; simplify_spec (tlul_adapter_reg (reg_count:=2));
-                simplify_invariant incr;
-                logical_simplify; tlsimpl; subst;
-                  cbn in Hinv'; logical_simplify; subst.
-      + destruct r.
-        * (* [r:=VALUE] *)
-          inversion_rel_spec; inversion_rel_base; destruct H6; subst.
-          cbn; replace (N.land (word_to_N (word.of_Z 16384)) 4) with 0%N
-            by (rewrite Z_word_N by lia; reflexivity);
-          cbn; eapply Inflight_read_value; [eauto| |reflexivity..].
-          logical_simplify. assumption.
-        * (* [r:=STATUS] *)
-          inversion_rel_spec; inversion_rel_base; subst; logical_simplify; subst; cbn.
-            eapply Inflight_read_status; try (constructor; lia).
-          all: replace (N.land (word_to_N (word.of_Z 16388)) 4) with 4%N
-            by (rewrite Z_word_N by lia; reflexivity); eauto.
-          all: cbn; replace ((word_to_N val + 1) mod 4294967296)%N with
-                        (word_to_N (word.add (word.of_Z 1) val)) by
-              (unfold word_to_N; ZnWords); constructor.
+      { (* case 1: device ready, valid response *)
+        destruct r.
+        - (* [r:=VALUE] *)
+          inversion_rel_spec; destruct Hex_read; subst.
+          eexists; split; [|cbn; ssplit; try reflexivity].
+          + repeat eexists; [|eassumption].
+            simplify_tl_repr; constructor.
+          + simplify_tl_repr.
+            apply N_to_word_word_to_N.
+        - (* [r:=STATUS] *)
+          inversion_rel_spec.
+          + eexists; split; [repeat eexists; [|eassumption]|cbn; ssplit; try reflexivity];
+              simplify_tl_repr.
+            * constructor.
+            * unfold N_to_word, status_value; ZnWords.
 
-      + inversion_rel_spec; inversion_rel_base; subst; logical_simplify; subst; lia.
+          + destruct ncycles as [|]; [exfalso; lia|].
+            eexists; split; [repeat eexists; [|eassumption]|cbn; ssplit; try reflexivity];
+              simplify_tl_repr.
+            * destruct count as [|[|[|]]]; [exfalso; lia|..|exfalso; lia].
+              -- apply BUSY_related with (ncycles:=ncycles); lia.
+              -- rewrite incrN_word_to_bv; apply BUSY_done_related.
+            * right. eexists; ssplit; try reflexivity.
+              unfold N_to_word, status_value; ZnWords.
+
+          + eexists; split; [repeat eexists; [|eassumption]|cbn; ssplit; try reflexivity];
+              simplify_tl_repr.
+            * apply DONE_related.
+            * left. split; [|reflexivity].
+              unfold N_to_word, status_value; ZnWords.
+
+          + eexists; split; [repeat eexists; [|eassumption]|cbn; ssplit; try reflexivity];
+              simplify_tl_repr.
+            * apply DONE_related.
+            * unfold N_to_word, status_value; ZnWords.
+      }
+
+      { (* case 2: device ready, no valid response *)
+        exfalso; simplify_tl_repr.
+      }
+
+      { (* case 3: device not ready *)
+        ssplit.
+        - repeat eexists; [|eassumption].
+          inversion_rel_spec; simplify_tl_repr;
+            rewrite ? incrN_word_to_bv; try (constructor; lia).
+          all: destruct count as [|[|[|]]]; [exfalso; lia
+                                            |apply BUSY_related with (ncycles:=ncycles); lia
+                                            |apply BUSY_done_related
+                                            |exfalso; lia].
+        - simplify_tl_repr; lia.
+      }
 
     - (* [state_machine_read_to_device_ack_read_or_later] *)
-      intros ? ? ? ? ? ? [v [sH'' Hex_read]] [repr [Hrel Hinv]] **.
-      (* assert (Hex_rel: exists sL'' h2d', device.run1 sL'' (set_d_ready true h2d') = sL /\ *)
-      (*                               counter_related sH sL'' []). *)
-      (* { admit. } *)
-      (* logical_simplify. destruct H0 as [repr'' [Hrel'' Hinv'']]. *)
-      (* use_spec. 1: admit. *)
-      (* rename Hprec into Hprec''. rename repr' into repr'''. rename Erepr' into Erepr''. rename Hinv' into Hinv'''. *)
-      cbn in Hex_read. logical_simplify.
-      rewrite H2. clear H2. rename H3 into Hex_read.
-      use_spec.
-      1: simplify_spec incr; simplify_spec (tlul_adapter_reg (reg_count:=2)); simplify_spec Incr.inner;
-        simplify_invariant incr;
-        cbn in sL; destruct sL as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner));
-          destruct repr as (((?r_state, ?r_regs), ?r_tl), ?r_inner);
-          destruct r_state;
-          destruct_tl_h2d; tlsimpl; logical_simplify; subst;
-            ssplit; intros; auto.
-
-      destruct_one_match.
-      (* case 2: no valid response
-         If the inflight queue is not empty, the device must be sending a
-         response, hence this case is not possible. *)
-      2: unfold device.last_d2h, counter_device in *;
-        cbn in sL; destruct sL as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner));
-          destruct repr as (((?r_state, ?r_regs), ?r_tl), ?r_inner);
-          simplify_invariant incr; subst; logical_simplify; destruct_tl_d2h; tlsimpl; subst;
-            inversion_rel_spec; try inversion_rel_base; logical_simplify; subst;
-              try destruct r_tl; logical_simplify; subst;
-                discriminate.
-
-      (* case 1: valid response *)
-      destruct r.
-      + (* [r:=VALUE] *)
-        inversion_rel_spec;
-          try (exfalso; destruct_tl_h2d; tlsimpl; subst; unfold word_to_N in *; cbn in *; ZnWords).
-
-        destruct Hex_read; subst.
-        logical_simplify; subst.
-        exists IDLE. ssplit.
-        * eexists. split; [|eassumption].
-          cbn.
-          cbn in sL; destruct sL as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner));
-            simplify_invariant incr;
-            logical_simplify; tlsimpl; subst.
-          apply No_inflight, IDLE_related.
-        * cbn. ssplit; try reflexivity.
-          clear Hinv'.
-          cbn in sL; destruct sL as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner));
-          simplify_invariant incr.
-          logical_simplify; subst.
-          destruct_tl_h2d; tlsimpl; subst.
-          rewrite H19. cbn. rewrite H3. apply N_to_word_word_to_N.
-      + (* [r:=STATUS] *)
-        inversion_rel_spec;
-          try (exfalso; destruct_tl_h2d; tlsimpl; subst; unfold word_to_N in *; cbn in *; ZnWords).
-
-        inversion_rel_base;
-          cbn in sL |- *; destruct sL as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner));
-            simplify_invariant incr;
-            logical_simplify; subst; logical_simplify; subst;
-              match goal with
-              | H: d_data _ = _ |- _ =>
-                rewrite H
-              end;
-              cbn; destruct_tl_h2d; tlsimpl; subst; cbn;
-              change (Pos.to_nat 1) with 1.
-                (* match goal with *)
-                (* | H: nth 1 r_tl_regs 0%N = _ |- _ => rewrite H *)
-                (* end; *)
-                (* unfold N_to_word, status_value. *)
-        * eexists; ssplit; try reflexivity.
-          -- eexists.
-             ssplit; [|eassumption].
-             apply No_inflight. constructor.
-          -- assert (Hprev: r_prev_state = RSIdle) by admit.
-             subst.
-             match goal with
-             | H: nth 1 r_tl_regs 0%N = _ |- _ => rewrite H
-             end; unfold N_to_word, status_value.
-             ZnWords.
-        * destruct ncycles as [|ncycles]; [lia|].
-          eexists; ssplit; try reflexivity.
-          -- eexists. ssplit; [|eassumption].
-             apply No_inflight, BUSY2_related. apply lt_S_n. eauto.
-          -- right. eexists. ssplit; [reflexivity| |reflexivity].
-             assert (Hprev: exists d, r_prev_state = RSBusy d) by admit.
-             logical_simplify; subst.
-             match goal with
-             | H: nth 1 r_tl_regs 0%N = _ |- _ => rewrite H
-             end; unfold N_to_word, status_value.
-             ZnWords.
-        * destruct ncycles as [|ncycles]; [lia|].
-          eexists. ssplit; try reflexivity.
-          -- eexists. ssplit; [|eassumption].
-             cbn; rewrite incrN_word_to_bv.
-             apply No_inflight, BUSY_done_related.
-          -- right. eexists. ssplit; [reflexivity| |reflexivity].
-             assert (Hprev: exists d, r_prev_state = RSBusy d) by admit.
-             logical_simplify; subst.
-             match goal with
-             | H: nth 1 r_tl_regs 0%N = _ |- _ => rewrite H
-             end; unfold N_to_word, status_value.
-             ZnWords.
-        * eexists; ssplit; try reflexivity.
-          -- eexists. ssplit; [|eassumption].
-             apply No_inflight, DONE_related.
-          -- left. ssplit; [|reflexivity].
-             assert (Hprev: exists d, r_prev_state = RSDone d) by admit.
-             logical_simplify; subst; logical_simplify;
-             match goal with
-             | H: nth 1 r_tl_regs 0%N = _ |- _ => rewrite H
-             end; unfold N_to_word, status_value.
-             ZnWords.
-        * eexists; ssplit; try reflexivity.
-          -- eexists. ssplit; [|eassumption].
-             apply No_inflight, DONE_related.
-          -- assert (Hprev: exists d, r_prev_state = RSDone d) by admit.
-             logical_simplify; subst; logical_simplify.
-             match goal with
-             | H: nth 1 r_tl_regs 0%N = _ |- _ => rewrite H
-             end; unfold N_to_word, status_value.
-             ZnWords.
+      intros.
+      unfold counter_related in *; logical_simplify.
+      discriminate.
 
     - (* [state_machine_write_to_device_send_write_or_later] *)
-      intros ? ? ? ? ? ? ? [sH'' [Hpow2 Hex_write]] [repr [Hrel Hinv]] **.
+      intros ? ? ? ? ? ? ? [sH'' [Hpow2 Hex_write]] **.
       rewrite Hpow2. clear Hpow2.
-      use_spec.
-      1: simplify_spec incr; simplify_spec (tlul_adapter_reg (reg_count:=2)); simplify_spec Incr.inner;
-        simplify_invariant incr;
-        cbn in sL; destruct sL as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner));
-          destruct repr as ((((?r_state, ?r_prev_state), ?r_regs), ?r_tl), ?r_inner);
-          destruct_tl_h2d; tlsimpl; logical_simplify; subst;
-            ssplit; intros; auto.
-
+      unfold counter_related in *. logical_simplify.
+      use_spec. clear Hprec.
       destruct_one_match; [destruct_one_match|].
-        (* case 1: device ready, valid response
-           In our TL implementation [a_ready = negb d_valid], hence this case
-           is not possible.
-           case 3: device not ready
-           If the inflight queue is empty, the device must be ready, hence
-           this case is not possible. *)
-      1,3: exfalso;
-        unfold device.last_d2h, counter_device in *;
-        cbn in sL; destruct sL as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner));
-        destruct repr as ((((?r_state, ?r_prev_state), ?r_regs), ?r_tl), ?r_inner);
-          simplify_invariant incr; subst; logical_simplify; destruct_tl_d2h; tlsimpl; subst;
-            inversion_rel_spec; logical_simplify; discriminate.
-      (* device ready, no valid response: *)
-      ssplit.
-      1: eexists; split; [|eassumption]; [].
-      all:
-        unfold device.tl_inflight_ops, device.last_d2h, device.maxRespDelay,
-        counter_device, counter_related in *;
-        cbn in sL; destruct sL as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner));
-          cbn in sL'; destruct sL' as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner));
-            destruct repr as ((((?r_state, ?r_prev_state), ?r_regs), ?r_tl), ?r_inner);
-            destruct_tl_d2h; destruct_tl_h2d;
-              simplify_spec incr; simplify_spec (tlul_adapter_reg (reg_count:=2));
-                simplify_invariant incr;
-                logical_simplify; tlsimpl; subst;
-                  cbn in Hinv'; logical_simplify; subst.
-      + destruct r.
-        * (* [r:=VALUE] *)
-          inversion_rel_spec; inversion_rel_base; logical_simplify; subst; try contradiction.
-          cbn. apply Inflight_write_value; eauto; [].
-          rewrite Z_word_N by lia. change (Z.to_N 16384) with 16384%N. reflexivity.
-        * (* [r:=STATUS] *)
-          inversion_rel_spec; inversion_rel_base;
+
+      { (* case 1: device ready, valid response *)
+        destruct r.
+        + (* [r:=VALUE] *)
+          inversion_rel_spec; destruct Hex_write; subst.
+          eexists; split; [|cbn; ssplit; try reflexivity].
+          repeat eexists; [|eassumption].
+          simplify_tl_repr; constructor; lia.
+        + (* [r:=STATUS] *)
           destruct Hex_write.
-      + inversion_rel_spec; inversion_rel_base; subst; logical_simplify; subst; lia.
+      }
+
+      { (* case 2: device ready, no valid response *)
+        exfalso; simplify_tl_repr.
+      }
+
+      { (* case 3: device not ready *)
+        ssplit.
+        - repeat eexists; [|eassumption].
+          inversion_rel_spec; simplify_tl_repr;
+            rewrite ? incrN_word_to_bv; try (constructor; lia).
+          all: destruct count as [|[|[|]]]; [exfalso; lia
+                                            |apply BUSY_related with (ncycles:=ncycles); lia
+                                            |apply BUSY_done_related
+                                            |exfalso; lia].
+        - simplify_tl_repr; lia.
+      }
 
     - (* [state_machine_write_to_device_ack_write_or_later] *)
-      intros ? ? ? ? ? ? ? [sH'' [Hpow2 Hex_write]] [repr [Hrel Hinv]] **.
-      rewrite Hpow2 in *. clear Hpow2.
-      use_spec.
-      1: simplify_spec incr; simplify_spec (tlul_adapter_reg (reg_count:=2)); simplify_spec Incr.inner;
-        simplify_invariant incr;
-        cbn in sL; destruct sL as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner));
-          destruct repr as ((((?r_state, ?r_prev_state), ?r_regs), ?r_tl), ?r_inner);
-          destruct_tl_h2d; tlsimpl; logical_simplify; subst;
-            ssplit; intros; auto.
+      intros.
+      unfold counter_related in *; logical_simplify.
+      discriminate.
 
-      destruct_one_match.
-      (* case 2: no valid response
-         If the inflight queue is not empty, the device must be sending a
-         response, hence this case is not possible. *)
-      2: unfold device.last_d2h, counter_device in *;
-        cbn in sL; destruct sL as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner));
-          destruct repr as ((((?r_state, ?r_prev_state), ?r_regs), ?r_tl), ?r_inner);
-          simplify_invariant incr; subst; logical_simplify; destruct_tl_d2h; tlsimpl; subst;
-            inversion_rel_spec; try inversion_rel_base; logical_simplify; subst;
-              try destruct r_tl; logical_simplify; subst;
-                discriminate.
-
-      (* case 1: valid response *)
-      destruct r.
-      + (* [r:=VALUE] *)
-        inversion_rel_spec;
-          try (exfalso; destruct_tl_h2d; tlsimpl; subst; unfold word_to_N in *; cbn in *; ZnWords).
-
-        destruct Hex_write; subst.
-        logical_simplify; subst.
-        eexists. ssplit; [|cbn; split; reflexivity].
-        eexists. split; [|eassumption].
-        cbn.
-        cbn in sL; destruct sL as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner));
-            simplify_invariant incr;
-            logical_simplify; tlsimpl; subst.
-        apply No_inflight.
-        simplify_invariant Incr.inner; destruct s_inner; logical_simplify.
-        destruct x as [|[|[|]]]; [exfalso; lia|..| exfalso; lia];
-          destruct_tl_h2d; tlsimpl; subst;
-            match goal with
-            | H: word_to_N v = word_to_N val |- _ =>
-              rewrite <- H
-            end.
-        * constructor; lia.
-        * replace ((word_to_N v + 1) mod 4294967296)%N with
-                        (word_to_N (word.add (word.of_Z 1) v)) by
-              (unfold word_to_N; ZnWords).
-          constructor.
-      + (* [r:=STATUS] *)
-        inversion_rel_spec;
-          try (exfalso; destruct_tl_h2d; tlsimpl; subst; unfold word_to_N in *; cbn in *; ZnWords).
     - (* read_step_unique: *)
       intros. simpl in *. unfold read_step in *. simp.
       destruct v; destruct r; try contradiction; simp; try reflexivity.

--- a/firmware/IncrementWait/CavaIncrementDevice.v
+++ b/firmware/IncrementWait/CavaIncrementDevice.v
@@ -57,9 +57,6 @@ Section WithParameters.
 
     device.last_d2h '((_, (_, (_, d2h))), _) := d2h;
 
-    device.tl_inflight_ops '((_, (_, (_, d2h))), _) :=
-      if d_valid d2h then [d_source d2h] else [];
-
     device.run1 s i := fst (Semantics.step incr s (i, tt));
 
     device.addr_range_start := INCR_BASE_ADDR;

--- a/firmware/IncrementWait/CavaIncrementDevice.v
+++ b/firmware/IncrementWait/CavaIncrementDevice.v
@@ -53,7 +53,7 @@ Section WithParameters.
     device.state := denote_type (state_of incr);
 
     device.is_ready_state s := exists r_regs r_tl r_inner,
-        incr_invariant s (RSIdle, r_regs, r_tl, r_inner);
+        incr_invariant s (ReprIdle, r_regs, r_tl, r_inner);
 
     device.last_d2h '((_, (_, (_, d2h))), _) := d2h;
 
@@ -72,17 +72,17 @@ Section WithParameters.
 
 
   Inductive counter_related_spec: IncrementWaitSemantics.state -> Incr.repr_state -> Prop :=
-  | IDLE_related: counter_related_spec IDLE RSIdle
+  | IDLE_related: counter_related_spec IDLE ReprIdle
   | BUSY_related: forall val ncycles count,
       (0 < count <= 2)%nat ->
       (2 < ncycles + count)%nat ->
-      counter_related_spec (BUSY val ncycles) (RSBusy (word_to_N val) count)
+      counter_related_spec (BUSY val ncycles) (ReprBusy (word_to_N val) count)
   (* the hardware is already done, but the software hasn't polled it yet to find out,
      so we have to relate a software-BUSY to a hardware-done: *)
   | BUSY_done_related: forall val ncycles,
-      counter_related_spec (BUSY val ncycles) (RSDone (word_to_N (word.add (word.of_Z 1) val)))
+      counter_related_spec (BUSY val ncycles) (ReprDone (word_to_N (word.add (word.of_Z 1) val)))
   | DONE_related: forall val,
-      counter_related_spec (DONE val) (RSDone (word_to_N val)).
+      counter_related_spec (DONE val) (ReprDone (word_to_N val)).
 
   Definition counter_related {invariant : invariant_for incr repr} (sH : IncrementWaitSemantics.state)
              (sL : denote_type (state_of incr)) (inflight_h2ds : list tl_h2d) : Prop :=

--- a/firmware/IncrementWait/CavaIncrementDevice.v
+++ b/firmware/IncrementWait/CavaIncrementDevice.v
@@ -1,18 +1,25 @@
-From Coq Require Import
-     Lists.List
-     ZArith.ZArith.
+Require Import Coq.Lists.List.
+Require Import Coq.micromega.Lia.
+Require Import Coq.ZArith.ZArith.
+
+Require Import Cava.Expr.
+Require Import Cava.ExprProperties.
+Require Import Cava.Invariant.
+Require Import Cava.Primitives.
+Require Import Cava.Semantics.
+Require Import Cava.TLUL.
+Require Import Cava.Types.
+Require Import Cava.Util.BitArithmetic.
+Require Import Cava.Util.List.
+Require Import Cava.Util.Tactics.
+
+Require Import coqutil.Tactics.Simp.
+Require Import coqutil.Tactics.Tactics.
 
 Import ListNotations.
 
-From Cava Require Import
-     Expr
-     Primitives
-     Semantics
-     TLUL
-     Types
-     Util.BitArithmetic.
-
 Section Var.
+  Import Expr.
   Import ExprNotations.
   Import PrimitiveNotations.
 
@@ -25,6 +32,31 @@ Section Var.
   Definition Busy1      := Constant incr_state 1.
   Definition Busy2      := Constant incr_state 2.
   Definition Done       := Constant incr_state 3.
+
+  Definition inner
+    : Circuit _ [Bit; BitVec 32] (Bit ** BitVec 32)
+    := {{
+      fun valid data =>
+        let/delay '(istate; value) :=
+           let istate' :=
+               if istate == `Busy1` then `Busy2`
+               else if istate == `Busy2` then `Done`
+                    else if istate == `Done` then `Idle`
+                         else (* istate == `Idle` *)
+                           if valid then `Busy1`
+                           else `Idle` in
+
+           let value' :=
+               if istate == `Busy2` then value + `K 1`
+               else if istate == `Idle` then data
+                    else value in
+
+           (istate', value')
+             initially default
+           : denote_type (incr_state ** BitVec 32)
+        in
+        (istate == `Done`, value)
+       }}.
 
   Definition incr
     : Circuit _ [tl_h2d_t] tl_d2h_t
@@ -42,8 +74,8 @@ Section Var.
               , a_data
               , a_user
               ; d_ready) := tl_h2d in
-        (* Bit #2 of the address determines which register is being accessed
-           (STATUS or VALUE). Zero out the other bits. *)
+        (* Bit #2 of the address determines which register is being accessed *)
+        (*    (STATUS or VALUE). Zero out the other bits. *)
         let a_address := a_address & (`K 1` << 2) in
         let tl_h2d := (a_valid
                        , a_opcode
@@ -56,49 +88,45 @@ Section Var.
                        , a_user
                        , d_ready) in
 
-        let/delay '(istate, value; tl_d2h) :=
-           (* Compute the value of the status register *)
-           let status :=
-               if istate == `Done` then `K 4`
-               else if istate == `Busy1` || istate == `Busy2` then `K 2`
-                    else (* istate == `Idle` *) `K 1` in
+        let/delay '(busy, done, registers; tl_d2h) :=
+           let '(tl_d2h'; req) := `tlul_adapter_reg` tl_h2d registers in
+           let '(is_read, is_write, address, write_data; _write_mask) := req in
 
-           (* Handle the input:
-              - a_opcode = Get: the adapter will do all the work;
-              - a_opcode = PutFullData: further handling is needed, the adapter
-                will output more info to req. *)
-           let '(tl_d2h'; req) := `tlul_adapter_reg` tl_h2d (value :> status :> []) in
-           let '(is_read
-                 , is_write
-                 , address
-                 , write_data
-                 ; _write_mask) := req in
+           let '(inner_res_valid; inner_res) := `inner` (!busy && !done && is_write) write_data in
 
-           let istate' :=
-               if istate == `Busy1` then `Busy2`
-               else if istate == `Busy2` then `Done`
-                    else if istate == `Done` then
-                           if is_read && address == `K 0` then `Idle`
-                           else `Done`
-                         else (* istate == `Idle` *)
-                           if is_write then `Busy1`
-                           else `Idle` in
+           let busy' :=
+               if busy then !inner_res_valid
+               else !done && is_write in
 
-           let value' :=
-               if istate == `Busy2` then value + `K 1`
-               else if istate == `Idle` then write_data
-                    else value in
+           let done' :=
+               if busy then inner_res_valid
+               else if done then !(is_read && address == `K 0`)
+                    else done in
 
-           (istate', value', tl_d2h')
-             initially (0,
-                        (0,
-                         (false, (0, (0, (0, (0, (0, (0, (0, (false, false)))))))))))
-           : denote_type (incr_state ** BitVec 32 ** tl_d2h_t)
+           let registers' :=
+               if inner_res_valid then `replace` registers `K (sz:=1) 0` inner_res
+               else registers in
+
+           let registers' :=
+               if busy' then `replace` registers' `K (sz:=1) 1` `K 2`
+               else if done' then `replace` registers' `K (sz:=1) 1` `K 4`
+                    else `replace` registers' `K (sz:=1) 1` `K 1` in
+
+           (busy', done', registers', tl_d2h') initially default
+           : denote_type (Bit ** Bit ** Vec (BitVec 32) 2 ** tl_d2h_t)
         in
 
         tl_d2h
        }}.
 End Var.
+
+Definition sim {s i o} (c : Circuit s i o) (input : list (denote_type i))
+  : list (denote_type s * denote_type i * denote_type o) :=
+  fst (List.fold_left (fun '(acc, s) i =>
+                         let '(s', o) := step c s i in
+                         (acc ++ [(s, i, o)], s'))
+                      input
+                      ([], reset_state c)).
 
 Example sample_trace :=
   Eval compute in
@@ -117,20 +145,481 @@ Example sample_trace :=
         (set_a_data v
         (set_d_ready true tl_h2d_default))))) in
 
-    simulate incr
-             [ (nop, tt)
-               ; (read_reg 4, tt) (* status *)
-               ; (nop, tt)
-               ; (write_val 42, tt)
-               ; (nop, tt)
-               ; (nop, tt)
-               ; (read_reg 4, tt) (* status *)
-               ; (nop, tt)
-               ; (read_reg 0, tt) (* value *)
-               ; (nop, tt)
-               ; (read_reg 4, tt) (* status *)
-             ]%N.
+    sim incr
+        [ (nop, tt)
+          ; (read_reg 4, tt) (* status *)
+          ; (nop, tt)
+          ; (write_val 42, tt)
+          ; (nop, tt)
+          ; (nop, tt)
+          ; (read_reg 4, tt) (* status *)
+          ; (nop, tt)
+          ; (read_reg 0, tt) (* value *)
+          ; (nop, tt)
+          ; (read_reg 4, tt) (* status *)
+        ]%N.
 (* Print sample_trace. *)
+
+Section Spec.
+  Local Open Scope N.
+
+  Variant inner_state :=
+  | IISIdle
+  | IISBusy (data : N) (count : nat)
+  | IISDone (res : N).
+
+  Notation inner_repr := inner_state.
+
+  Global Instance inner_invariant : invariant_for inner inner_repr :=
+    fun (state : denote_type (state_of inner)) repr =>
+      let '(istate, value) := state in
+      match repr with
+      | IISIdle => istate = 0
+      | IISBusy data c => (0 < c <= 2)%nat /\ istate = N.of_nat c /\ value = data
+      | IISDone res => istate = 3 /\ value = res
+      end.
+
+  Definition inner_spec_step (input : denote_type (input_of inner)) repr :=
+    let '(valid, (data, tt)) := input in
+    match repr with
+    | IISIdle => if valid then IISBusy data 1 else IISIdle
+    | IISBusy data 2 => IISDone ((data + 1) mod 2^32)
+    | IISBusy data c => IISBusy data (c + 1)
+    | IISDone _ => IISIdle
+    end.
+
+  Instance inner_specification
+    : specification_for inner inner_repr :=
+    {| reset_repr := IISIdle;
+
+       update_repr :=
+         fun (input : denote_type (input_of inner)) repr =>
+           inner_spec_step input repr;
+
+       precondition :=
+         fun (input : denote_type (input_of inner)) repr => True;
+
+       postcondition :=
+         fun (input : denote_type (input_of inner)) repr
+           (output : denote_type (output_of inner)) =>
+           let repr' := inner_spec_step input repr in
+           match repr' with
+           | IISDone res => output = (true, res)
+           | _ => exists res, output = (false, res)
+           end;
+    |}.
+
+  Lemma inner_invariant_at_reset : invariant_at_reset inner.
+  Proof.
+    simplify_invariant inner. reflexivity.
+  Qed.
+
+  Lemma inner_invariant_preserved : invariant_preserved inner.
+  Proof.
+    intros (valid, (data, t)) state repr. destruct t.
+    cbn in * |-. destruct state as (istate, value).
+    intros repr' ? Hinvar Hprec; subst.
+    simplify_invariant inner.
+    simplify_spec inner.
+    cbv [inner inner_spec_step]. stepsimpl.
+    repeat (destruct_pair_let; cbn [fst snd]).
+    destruct repr as [|? iiscount|?]; logical_simplify; subst.
+    - destruct valid; cbn; try ssplit; lia.
+    - destruct iiscount as [|[|[|iiscount]]]; cbn; ssplit; lia.
+    - reflexivity.
+  Qed.
+
+  Lemma inner_output_correct : output_correct inner.
+  Proof.
+    intros (valid, (data, t)) state repr. destruct t.
+    cbn in * |-. destruct state as (istate, value).
+    remember (update_repr (c:=inner) (valid, (data, tt)) repr) as repr'.
+    intros Hinvar Hprec.
+    simplify_invariant inner.
+    simplify_spec inner.
+    cbv [inner inner_spec_step]. stepsimpl.
+    repeat (destruct_pair_let; cbn [fst snd]).
+    destruct repr as [|? iiscount|?]; logical_simplify; subst.
+    - destruct valid; eexists; cbn; try ssplit; reflexivity.
+    - destruct iiscount as [|[|[|iiscount]]]; try lia; try eexists; reflexivity.
+    - eexists. reflexivity.
+  Qed.
+
+  Existing Instances inner_invariant_at_reset inner_invariant_preserved
+           inner_output_correct.
+  Global Instance inner_correctness : correctness_for inner.
+  Proof. constructor; typeclasses eauto. Defined.
+
+
+  Variant repr_state :=
+  | RSIdle
+  | RSBusy (data : N)
+  | RSDone (res : N).
+
+  Notation repr := (repr_state * list N * list tl_h2d * inner_repr)%type.
+
+  Global Instance incr_invariant : invariant_for incr repr :=
+    fun (state : denote_type (state_of incr)) repr =>
+      let '((s_busy, (s_done, (s_regs, s_d2h))), (s_tlul, s_inner)) := state in
+      let '(r_state, r_regs, r_tlul, r_inner) := repr in
+      tlul_invariant (reg_count:=2) s_tlul r_tlul
+      /\ inner_invariant s_inner r_inner
+      /\ match r_state with
+        | RSIdle => s_busy = false /\ s_done = false
+                   /\ r_inner = IISIdle
+        | RSBusy data => s_busy = true /\ s_done = false
+                        /\ exists c, r_inner = IISBusy data c
+        | RSDone res => s_busy = false /\ s_done = true
+                       /\ (r_inner = IISDone res \/ r_inner = IISIdle)
+        end
+      /\ s_regs = r_regs.
+
+  Existing Instance tlul_specification.
+
+  Instance incr_specification
+    : specification_for incr repr :=
+    {| reset_repr := (RSIdle, [0; 0], [], IISIdle);
+
+       update_repr :=
+         fun (input : denote_type (input_of incr)) repr =>
+           let '(i_h2d, tt) := input in
+           let '(r_state, r_regs, r_tlul, r_inner) := repr in
+
+           let h2d := set_a_address (N.land (a_address i_h2d) 4) i_h2d in
+
+           let r_tlul' :=
+               let tlul_input := (h2d, (r_regs, tt)) in
+               update_repr (c:=tlul_adapter_reg (reg_count:=2))
+                           tlul_input r_tlul in
+
+           (* compute (some) tlul output *)
+           let '(is_read, is_write, address, write_data) :=
+               match outstanding_h2d (h2d :: r_tlul) with
+               | None => (false, false, 0, 0)
+               | Some h2d' =>
+                 if a_opcode h2d' =? Get then
+                   match outstanding_h2d r_tlul with
+                   | None => (a_valid h2d, false, a_address h2d, 0)
+                   | _ => (false, false, 0, 0)
+                   end
+                 else if a_opcode h2d' =? PutFullData then
+                   match outstanding_h2d r_tlul with
+                   | None => (false, a_valid h2d, a_address h2d, a_data h2d)
+                   | _ => (false, false, 0, 0)
+                   end
+                 else (false, false, 0, 0)
+               end in
+
+           let r_inner' :=
+               let inner_input := (match r_state with RSIdle => is_write | _ => false end, (write_data, tt)) in
+               update_repr (c:=inner) inner_input r_inner in
+
+           let r_state' :=
+               match r_state with
+               | RSDone _ =>
+                 if negb (is_read && (address =? 0)) then r_state
+                 else RSIdle
+               | _ =>
+                 match r_inner' with
+                 | IISBusy data _ => RSBusy data
+                 | IISDone res => RSDone res
+                 | _ => r_state
+                 end
+               end in
+
+           let r_regs' :=
+               match r_inner' with
+               | IISDone res => replace 0 res r_regs
+               | _ => r_regs
+               end in
+
+           let r_regs' :=
+               match r_state' with
+               | RSIdle => replace 1 1 r_regs'
+               | RSBusy _ => replace 1 2 r_regs'
+               | RSDone _ => replace 1 4 r_regs'
+               end in
+
+           (r_state', r_regs', h2d :: r_tlul, r_inner');
+
+       precondition :=
+         fun (input : denote_type (input_of incr)) repr =>
+           let '(i_h2d, tt) := input in
+           let '(r_state, r_regs, r_tlul, r_inner) := repr in
+
+           let h2d := set_a_address (N.land (a_address i_h2d) 4) i_h2d in
+
+           let tlul_input := (h2d, (r_regs, tt)) in
+
+           let prec_tlul :=
+               precondition (tlul_adapter_reg (reg_count:=2))
+                            tlul_input r_tlul in
+
+           let prec_inner :=
+               forall d2h is_read is_write address write_data write_mask,
+                 postcondition (tlul_adapter_reg (reg_count:=2))
+                               tlul_input r_tlul
+                               (d2h, (is_read, (is_write, (address, (write_data, write_mask)))))
+                 -> precondition inner (match r_state with RSIdle => is_write | _ => false end, (write_data, tt)) r_inner in
+
+           prec_tlul /\ prec_inner;
+
+       postcondition :=
+         fun (input : denote_type (input_of incr)) repr
+           (output : denote_type (output_of incr)) =>
+           let '(i_h2d, tt) := input in
+           let '(r_state, r_regs, r_tlul, r_inner) := repr in
+
+           let h2d := set_a_address (N.land (a_address i_h2d) 4) i_h2d in
+
+           let postc_tlul :=
+               let tlul_input := (h2d, (r_regs, tt)) in
+               exists req,
+                 postcondition (tlul_adapter_reg (reg_count:=2))
+                               tlul_input r_tlul
+                               (output, req) in
+           postc_tlul;
+    |}.
+
+  Lemma incr_invariant_at_reset : invariant_at_reset incr.
+  Proof.
+    simplify_invariant incr.
+    cbn. ssplit; try reflexivity.
+    apply (tlul_adapter_reg_invariant_at_reset (reg_count:=2)).
+  Qed.
+
+  Existing Instance tlul_adapter_reg_correctness.
+
+  (* TODO: move these lemmas to TLUL.v *)
+  Lemma outstanding_in_repr {reg_count : nat} : forall r_tlul t,
+      outstanding_h2d r_tlul = Some t ->
+      In t r_tlul.
+  Proof.
+    intros ? ?.
+    induction r_tlul; intros Houts; cbn in Houts.
+    - discriminate.
+    - destruct (outstanding_h2d r_tlul) eqn:Houts'.
+      + destruct d_ready.
+        * discriminate.
+        * apply in_cons. auto.
+      + destruct (a_valid a).
+        * inversion Houts. apply in_eq.
+        * discriminate.
+  Qed.
+
+  Lemma outstanding_a_valid {reg_count : nat} : forall r_tlul t,
+      outstanding_h2d r_tlul = Some t ->
+      a_valid t = true.
+  Proof.
+    intros ? ?.
+    induction r_tlul; intros Houts; cbn in Houts.
+    - discriminate.
+    - destruct (outstanding_h2d r_tlul) eqn:Houts'.
+      + destruct d_ready.
+        * discriminate.
+        * auto.
+      + destruct (a_valid a) eqn:Hvalid.
+        * inversion Houts. subst. assumption.
+        * discriminate.
+  Qed.
+
+  Lemma outstanding_prec {reg_count : nat} : forall tl_st r_tlul t,
+      tlul_invariant (reg_count:=reg_count) tl_st r_tlul ->
+      outstanding_h2d r_tlul = Some t ->
+      a_opcode t = Get \/ a_opcode t = PutFullData.
+  Proof.
+    intros ? ? ? Hinvar Houts. simpl in *.
+    apply (outstanding_in_repr (reg_count:=reg_count)) in Houts as Hin.
+    unfold tlul_invariant in Hinvar. logical_simplify.
+    eapply Forall_forall in H. 2: apply Hin.
+    apply H.
+    eapply (outstanding_a_valid (reg_count:=reg_count)).
+    apply Houts.
+  Qed.
+
+
+  Lemma incr_invariant_preserved : invariant_preserved incr.
+  Proof.
+    intros (h2d, t) state (((r_state, r_regs), r_tlul), r_inner). destruct t.
+    cbn in * |-. destruct state as ((busy, (done, (registers, d2h))), (tl_st, inner_st)).
+    destruct_tl_h2d. destruct_tl_d2h.
+    intros repr' ? Hinvar Hprec; subst.
+    simplify_invariant incr. logical_simplify. subst.
+    simplify_spec incr. logical_simplify. subst.
+    (* destruct Hprec as [regs Hprec]. *)
+    cbv [incr]. stepsimpl.
+    use_correctness.
+    match goal with
+    | H: (match outstanding_h2d (_::r_tlul) with | _ => _ end) |- _ =>
+      rename H into Htl_postc
+    end.
+    repeat (destruct_pair_let; cbn [fst snd]).
+    ssplit.
+    - eapply tlul_adapter_reg_invariant_preserved.
+      2: apply H.
+      + reflexivity.
+      + assumption.
+    - eapply inner_invariant_preserved.
+      2: apply H0.
+      + simpl in *.
+        destruct r_inner; try reflexivity.
+        destruct (outstanding_h2d r_tlul) eqn:Houts.
+        * destruct d_ready; logical_simplify; subst.
+          -- boolsimpl. destruct r_state; reflexivity.
+          -- eapply outstanding_prec in H as Hprec_t. 2: apply Houts.
+             destruct Hprec_t as [Hprec_t|Hprec_t];
+               rewrite Hprec_t in *; cbn in Htl_postc |- *; logical_simplify; subst;
+                 boolsimpl; destruct r_state; reflexivity.
+        * destruct a_valid eqn:Hvalid; logical_simplify; subst.
+          -- cbn in Htl_postc.
+             match goal with
+             | H: true = true -> _ |- _ =>
+               destruct H; try reflexivity; subst
+             end; cbn in Htl_postc; logical_simplify; subst;
+               boolsimpl; destruct r_state; logical_simplify; subst;
+                 reflexivity.
+          -- boolsimpl; destruct r_state; reflexivity.
+      + match goal with
+        | H: context [_ -> precondition inner _ r_inner] |- _ =>
+          eapply H
+        end.
+        do 8 eexists. ssplit.
+        1-2: reflexivity.
+        apply Htl_postc.
+    - match goal with
+      | H: context [_ -> precondition inner _ r_inner] |- _ => clear H
+      end.
+      destruct r_inner; destruct r_state; destruct inner_st;
+        unfold inner_invariant in H0; logical_simplify; subst;
+          try discriminate;
+          try (destruct H4; discriminate).
+      all: destruct (outstanding_h2d r_tlul) eqn:Houts;
+        cbn [outstanding_h2d] in Htl_postc |- *; rewrite Houts in Htl_postc |- *.
+      all: tlsimpl; destruct d_ready; logical_simplify; subst; boolsimpl.
+      all: cbn; try (ssplit; reflexivity).
+      all: try (eapply outstanding_prec in H;
+                try match goal with
+                    | H: outstanding_h2d _ = Some _ |- outstanding_h2d _ = Some _ =>
+                      apply H
+                    end; destruct H; rewrite H in Htl_postc |- *; cbn in Htl_postc |- *;
+                logical_simplify; subst; ssplit;
+                try (left; reflexivity);
+                try (right; reflexivity);
+                reflexivity).
+      all: try (destruct a_valid; simplify_spec (tlul_adapter_reg (reg_count:=2));
+                tlsimpl; destruct H2;
+                try match goal with
+                    | H: true = true -> _ |- _ =>
+                      destruct H; try reflexivity; subst
+                    end; cbn in Htl_postc; logical_simplify; subst; cbn; ssplit;
+                  try eexists; reflexivity).
+      all: try (destruct a_valid; ssplit;
+                try (left; reflexivity);
+                try (right; reflexivity);
+                reflexivity).
+      all: try (destruct a_valid; simplify_spec (tlul_adapter_reg (reg_count:=2));
+                tlsimpl; destruct H2;
+                try match goal with
+                    | H: true = true -> _ |- _ =>
+                      destruct H; try reflexivity; subst
+                    end; cbn in Htl_postc; logical_simplify; subst;
+                boolsimpl; destruct (negb (N.land a_address 4 =? 0)) eqn:Haddr;
+                cbn; try (rewrite Haddr); ssplit;
+                try (left; reflexivity);
+                try (right; reflexivity);
+                reflexivity).
+      all: (inversion H4; subst; clear H4;
+            destruct x as [|[|[|?]]]; cbn; ssplit;
+            try eexists;
+            try (left; reflexivity);
+            try (right; reflexivity);
+            try reflexivity;
+            exfalso; lia).
+    - match goal with
+      | H: context [_ -> precondition inner _ r_inner] |- _ => clear H
+      end.
+      destruct r_inner; destruct r_state; destruct inner_st;
+        unfold inner_invariant in H0; logical_simplify; subst;
+          try discriminate.
+      all: destruct (outstanding_h2d r_tlul) eqn:Houts;
+        cbn [outstanding_h2d] in Htl_postc |- *; rewrite Houts in Htl_postc |- *.
+      all: tlsimpl; destruct d_ready; logical_simplify; subst; boolsimpl.
+      all: try reflexivity.
+      all: try (eapply outstanding_prec in H;
+                try match goal with
+                    | H: outstanding_h2d _ = Some _ |- outstanding_h2d _ = Some _ =>
+                      apply H
+                    end; destruct H; rewrite H in Htl_postc |- *; cbn in Htl_postc |- *;
+                logical_simplify; subst; cbn; reflexivity).
+      all: try (destruct a_valid; simplify_spec (tlul_adapter_reg (reg_count:=2));
+                tlsimpl; destruct H2;
+                try match goal with
+                    | H: true = true -> _ |- _ =>
+                      destruct H; try reflexivity; subst
+                    end; cbn in Htl_postc; logical_simplify; subst; reflexivity).
+      all: try (destruct a_valid; simplify_spec (tlul_adapter_reg (reg_count:=2));
+                tlsimpl; destruct H2;
+                try match goal with
+                    | H: true = true -> _ |- _ =>
+                      destruct H; try reflexivity; subst
+                    end; cbn in Htl_postc; logical_simplify; subst;
+                boolsimpl; destruct (negb (N.land a_address 4 =? 0)) eqn:Haddr;
+                cbn; try (rewrite Haddr); reflexivity).
+      all: try (inversion H4; subst; clear H4;
+            destruct x as [|[|[|?]]]; try reflexivity; exfalso; lia).
+      all: try (destruct H4; discriminate).
+  Qed.
+
+  Lemma incr_output_correct : output_correct incr.
+  Proof.
+    intros (h2d, t) state (((r_state, r_regs), r_tlul), r_inner). destruct t.
+    cbn in * |-. destruct state as ((busy, (done, (registers, d2h))), (tl_st, inner_st)).
+    destruct_tl_h2d. destruct_tl_d2h.
+    intros Hinvar Hprec; subst.
+    simplify_invariant incr. logical_simplify. subst.
+    simplify_spec incr. logical_simplify. subst.
+    cbv [incr]. stepsimpl.
+    use_correctness.
+    match goal with
+    | H: (match outstanding_h2d (_::r_tlul) with | _ => _ end) |- _ =>
+      rename H into Htl_postc
+    end.
+    repeat (destruct_pair_let; cbn [fst snd]).
+    tlsimpl.
+    destruct r_inner; destruct r_state; destruct inner_st;
+      unfold inner_invariant in H0; logical_simplify; subst;
+        try discriminate;
+        try (destruct H5; discriminate).
+    all: destruct (outstanding_h2d r_tlul) eqn:Houts;
+      cbn [outstanding_h2d] in Htl_postc |- *; rewrite Houts in Htl_postc |- *.
+    all: tlsimpl; destruct d_ready; logical_simplify; subst; boolsimpl.
+    all: do 9 eexists.
+    all: ssplit; try reflexivity; tlsimpl; ssplit; try reflexivity; try assumption.
+    all: try (eapply outstanding_prec in H;
+              try match goal with
+                  | H: outstanding_h2d _ = Some _ |- outstanding_h2d _ = Some _ =>
+                    apply H
+                  end; destruct H; rewrite H in Htl_postc |- *; cbn in Htl_postc |- *;
+              logical_simplify; subst; ssplit;
+              try (left; reflexivity);
+              try (right; reflexivity);
+              try assumption;
+              reflexivity).
+    all: try (destruct a_valid; simplify_spec (tlul_adapter_reg (reg_count:=2));
+              tlsimpl; destruct H2;
+              try match goal with
+                  | H: true = true -> _ |- _ =>
+                    destruct H; try reflexivity; subst
+                  end; cbn in Htl_postc; logical_simplify; subst; cbn; ssplit;
+              try eexists; try assumption; reflexivity).
+    Unshelve. all: auto.
+  Qed.
+
+  Existing Instances incr_invariant_at_reset incr_invariant_preserved
+           incr_output_correct.
+  Global Instance incr_correctness : correctness_for incr.
+  Proof. constructor; typeclasses eauto. Defined.
+End Spec.
 
 Require Import Coq.micromega.Lia.
 

--- a/firmware/IncrementWait/CavaIncrementDevice.v
+++ b/firmware/IncrementWait/CavaIncrementDevice.v
@@ -13,633 +13,23 @@ Require Import Cava.Util.BitArithmetic.
 Require Import Cava.Util.List.
 Require Import Cava.Util.Tactics.
 
+Require Import coqutil.Map.Interface coqutil.Map.Properties.
 Require Import coqutil.Tactics.Simp.
 Require Import coqutil.Tactics.Tactics.
-
-Import ListNotations.
-
-Section Var.
-  Import Expr.
-  Import ExprNotations.
-  Import PrimitiveNotations.
-
-  Local Open Scope N.
-
-  Context {var : tvar}.
-
-  Definition incr_state := BitVec 2.
-  Definition Idle       := Constant incr_state 0.
-  Definition Busy1      := Constant incr_state 1.
-  Definition Busy2      := Constant incr_state 2.
-  Definition Done       := Constant incr_state 3.
-
-  Definition inner
-    : Circuit _ [Bit; BitVec 32] (Bit ** BitVec 32)
-    := {{
-      fun valid data =>
-        let/delay '(istate; value) :=
-           let istate' :=
-               if istate == `Busy1` then `Busy2`
-               else if istate == `Busy2` then `Done`
-                    else if istate == `Done` then `Idle`
-                         else (* istate == `Idle` *)
-                           if valid then `Busy1`
-                           else `Idle` in
-
-           let value' :=
-               if istate == `Busy2` then value + `K 1`
-               else if istate == `Idle` then data
-                    else value in
-
-           (istate', value')
-             initially default
-           : denote_type (incr_state ** BitVec 32)
-        in
-        (istate == `Done`, value)
-       }}.
-
-  Definition incr
-    : Circuit _ [tl_h2d_t] tl_d2h_t
-    := {{
-      fun tl_h2d =>
-        (* Destruct and reassemble tl_h2d with a_address that matches the
-           tlul_adapter_reg interface. *)
-        let '(a_valid
-              , a_opcode
-              , a_param
-              , a_size
-              , a_source
-              , a_address
-              , a_mask
-              , a_data
-              , a_user
-              ; d_ready) := tl_h2d in
-        (* Bit #2 of the address determines which register is being accessed *)
-        (*    (STATUS or VALUE). Zero out the other bits. *)
-        let a_address := a_address & (`K 1` << 2) in
-        let tl_h2d := (a_valid
-                       , a_opcode
-                       , a_param
-                       , a_size
-                       , a_source
-                       , a_address
-                       , a_mask
-                       , a_data
-                       , a_user
-                       , d_ready) in
-
-        let/delay '(busy, done, registers; tl_d2h) :=
-           let '(tl_d2h'; req) := `tlul_adapter_reg` tl_h2d registers in
-           let '(is_read, is_write, address, write_data; _write_mask) := req in
-
-           let '(inner_res_valid; inner_res) := `inner` (!busy && !done && is_write) write_data in
-
-           let busy' :=
-               if busy then !inner_res_valid
-               else !done && is_write in
-
-           let done' :=
-               if busy then inner_res_valid
-               else if done then !(is_read && address == `K 0`)
-                    else done in
-
-           let registers' :=
-               if inner_res_valid then `replace` registers `K (sz:=1) 0` inner_res
-               else registers in
-
-           let registers' :=
-               if busy' then `replace` registers' `K (sz:=1) 1` `K 2`
-               else if done' then `replace` registers' `K (sz:=1) 1` `K 4`
-                    else `replace` registers' `K (sz:=1) 1` `K 1` in
-
-           (busy', done', registers', tl_d2h') initially default
-           : denote_type (Bit ** Bit ** Vec (BitVec 32) 2 ** tl_d2h_t)
-        in
-
-        tl_d2h
-       }}.
-End Var.
-
-Definition sim {s i o} (c : Circuit s i o) (input : list (denote_type i))
-  : list (denote_type s * denote_type i * denote_type o) :=
-  fst (List.fold_left (fun '(acc, s) i =>
-                         let '(s', o) := step c s i in
-                         (acc ++ [(s, i, o)], s'))
-                      input
-                      ([], reset_state c)).
-
-Example sample_trace :=
-  Eval compute in
-    let nop := set_d_ready true tl_h2d_default in
-    let read_reg (r : N) :=
-        set_a_valid true
-        (set_a_opcode Get
-        (set_a_size 2%N
-        (set_a_address r
-        (set_d_ready true tl_h2d_default)))) in
-    let write_val (v : N) :=
-        set_a_valid true
-        (set_a_opcode PutFullData
-        (set_a_size 2%N
-        (set_a_address 0%N (* value-ref *)
-        (set_a_data v
-        (set_d_ready true tl_h2d_default))))) in
-
-    sim incr
-        [ (nop, tt)
-          ; (read_reg 4, tt) (* status *)
-          ; (nop, tt)
-          ; (write_val 42, tt)
-          ; (nop, tt)
-          ; (nop, tt)
-          ; (read_reg 4, tt) (* status *)
-          ; (nop, tt)
-          ; (read_reg 0, tt) (* value *)
-          ; (nop, tt)
-          ; (read_reg 4, tt) (* status *)
-        ]%N.
-(* Print sample_trace. *)
-
-Section Spec.
-  Local Open Scope N.
-
-  Variant inner_state :=
-  | IISIdle
-  | IISBusy (data : N) (count : nat)
-  | IISDone (res : N).
-
-  Notation inner_repr := inner_state.
-
-  Global Instance inner_invariant : invariant_for inner inner_repr :=
-    fun (state : denote_type (state_of inner)) repr =>
-      let '(istate, value) := state in
-      match repr with
-      | IISIdle => istate = 0
-      | IISBusy data c => (0 < c <= 2)%nat /\ istate = N.of_nat c /\ value = data
-      | IISDone res => istate = 3 /\ value = res
-      end.
-
-  Definition inner_spec_step (input : denote_type (input_of inner)) repr :=
-    let '(valid, (data, tt)) := input in
-    match repr with
-    | IISIdle => if valid then IISBusy data 1 else IISIdle
-    | IISBusy data 2 => IISDone ((data + 1) mod 2^32)
-    | IISBusy data c => IISBusy data (c + 1)
-    | IISDone _ => IISIdle
-    end.
-
-  Instance inner_specification
-    : specification_for inner inner_repr :=
-    {| reset_repr := IISIdle;
-
-       update_repr :=
-         fun (input : denote_type (input_of inner)) repr =>
-           inner_spec_step input repr;
-
-       precondition :=
-         fun (input : denote_type (input_of inner)) repr => True;
-
-       postcondition :=
-         fun (input : denote_type (input_of inner)) repr
-           (output : denote_type (output_of inner)) =>
-           let repr' := inner_spec_step input repr in
-           match repr' with
-           | IISDone res => output = (true, res)
-           | _ => exists res, output = (false, res)
-           end;
-    |}.
-
-  Lemma inner_invariant_at_reset : invariant_at_reset inner.
-  Proof.
-    simplify_invariant inner. reflexivity.
-  Qed.
-
-  Lemma inner_invariant_preserved : invariant_preserved inner.
-  Proof.
-    intros (valid, (data, t)) state repr. destruct t.
-    cbn in * |-. destruct state as (istate, value).
-    intros repr' ? Hinvar Hprec; subst.
-    simplify_invariant inner.
-    simplify_spec inner.
-    cbv [inner inner_spec_step]. stepsimpl.
-    repeat (destruct_pair_let; cbn [fst snd]).
-    destruct repr as [|? iiscount|?]; logical_simplify; subst.
-    - destruct valid; cbn; try ssplit; lia.
-    - destruct iiscount as [|[|[|iiscount]]]; cbn; ssplit; lia.
-    - reflexivity.
-  Qed.
-
-  Lemma inner_output_correct : output_correct inner.
-  Proof.
-    intros (valid, (data, t)) state repr. destruct t.
-    cbn in * |-. destruct state as (istate, value).
-    remember (update_repr (c:=inner) (valid, (data, tt)) repr) as repr'.
-    intros Hinvar Hprec.
-    simplify_invariant inner.
-    simplify_spec inner.
-    cbv [inner inner_spec_step]. stepsimpl.
-    repeat (destruct_pair_let; cbn [fst snd]).
-    destruct repr as [|? iiscount|?]; logical_simplify; subst.
-    - destruct valid; eexists; cbn; try ssplit; reflexivity.
-    - destruct iiscount as [|[|[|iiscount]]]; try lia; try eexists; reflexivity.
-    - eexists. reflexivity.
-  Qed.
-
-  Existing Instances inner_invariant_at_reset inner_invariant_preserved
-           inner_output_correct.
-  Global Instance inner_correctness : correctness_for inner.
-  Proof. constructor; typeclasses eauto. Defined.
-
-
-  Variant repr_state :=
-  | RSIdle
-  | RSBusy (data : N)
-  | RSDone (res : N).
-
-  Notation repr := (repr_state * list N * list tl_h2d * inner_repr)%type.
-
-  Global Instance incr_invariant : invariant_for incr repr :=
-    fun (state : denote_type (state_of incr)) repr =>
-      let '((s_busy, (s_done, (s_regs, s_d2h))), (s_tlul, s_inner)) := state in
-      let '(r_state, r_regs, r_tlul, r_inner) := repr in
-      tlul_invariant (reg_count:=2) s_tlul r_tlul
-      /\ inner_invariant s_inner r_inner
-      /\ match r_state with
-        | RSIdle => s_busy = false /\ s_done = false
-                   /\ r_inner = IISIdle
-        | RSBusy data => s_busy = true /\ s_done = false
-                        /\ exists c, r_inner = IISBusy data c
-        | RSDone res => s_busy = false /\ s_done = true
-                       /\ (r_inner = IISDone res \/ r_inner = IISIdle)
-        end
-      /\ s_regs = r_regs.
-
-  Existing Instance tlul_specification.
-
-  Instance incr_specification
-    : specification_for incr repr :=
-    {| reset_repr := (RSIdle, [0; 0], [], IISIdle);
-
-       update_repr :=
-         fun (input : denote_type (input_of incr)) repr =>
-           let '(i_h2d, tt) := input in
-           let '(r_state, r_regs, r_tlul, r_inner) := repr in
-
-           let h2d := set_a_address (N.land (a_address i_h2d) 4) i_h2d in
-
-           let r_tlul' :=
-               let tlul_input := (h2d, (r_regs, tt)) in
-               update_repr (c:=tlul_adapter_reg (reg_count:=2))
-                           tlul_input r_tlul in
-
-           (* compute (some) tlul output *)
-           let '(is_read, is_write, address, write_data) :=
-               match outstanding_h2d (h2d :: r_tlul) with
-               | None => (false, false, 0, 0)
-               | Some h2d' =>
-                 if a_opcode h2d' =? Get then
-                   match outstanding_h2d r_tlul with
-                   | None => (a_valid h2d, false, a_address h2d, 0)
-                   | _ => (false, false, 0, 0)
-                   end
-                 else if a_opcode h2d' =? PutFullData then
-                   match outstanding_h2d r_tlul with
-                   | None => (false, a_valid h2d, a_address h2d, a_data h2d)
-                   | _ => (false, false, 0, 0)
-                   end
-                 else (false, false, 0, 0)
-               end in
-
-           let r_inner' :=
-               let inner_input := (match r_state with RSIdle => is_write | _ => false end, (write_data, tt)) in
-               update_repr (c:=inner) inner_input r_inner in
-
-           let r_state' :=
-               match r_state with
-               | RSDone _ =>
-                 if negb (is_read && (address =? 0)) then r_state
-                 else RSIdle
-               | _ =>
-                 match r_inner' with
-                 | IISBusy data _ => RSBusy data
-                 | IISDone res => RSDone res
-                 | _ => r_state
-                 end
-               end in
-
-           let r_regs' :=
-               match r_inner' with
-               | IISDone res => replace 0 res r_regs
-               | _ => r_regs
-               end in
-
-           let r_regs' :=
-               match r_state' with
-               | RSIdle => replace 1 1 r_regs'
-               | RSBusy _ => replace 1 2 r_regs'
-               | RSDone _ => replace 1 4 r_regs'
-               end in
-
-           (r_state', r_regs', h2d :: r_tlul, r_inner');
-
-       precondition :=
-         fun (input : denote_type (input_of incr)) repr =>
-           let '(i_h2d, tt) := input in
-           let '(r_state, r_regs, r_tlul, r_inner) := repr in
-
-           let h2d := set_a_address (N.land (a_address i_h2d) 4) i_h2d in
-
-           let tlul_input := (h2d, (r_regs, tt)) in
-
-           let prec_tlul :=
-               precondition (tlul_adapter_reg (reg_count:=2))
-                            tlul_input r_tlul in
-
-           let prec_inner :=
-               forall d2h is_read is_write address write_data write_mask,
-                 postcondition (tlul_adapter_reg (reg_count:=2))
-                               tlul_input r_tlul
-                               (d2h, (is_read, (is_write, (address, (write_data, write_mask)))))
-                 -> precondition inner (match r_state with RSIdle => is_write | _ => false end, (write_data, tt)) r_inner in
-
-           prec_tlul /\ prec_inner;
-
-       postcondition :=
-         fun (input : denote_type (input_of incr)) repr
-           (output : denote_type (output_of incr)) =>
-           let '(i_h2d, tt) := input in
-           let '(r_state, r_regs, r_tlul, r_inner) := repr in
-
-           let h2d := set_a_address (N.land (a_address i_h2d) 4) i_h2d in
-
-           let postc_tlul :=
-               let tlul_input := (h2d, (r_regs, tt)) in
-               exists req,
-                 postcondition (tlul_adapter_reg (reg_count:=2))
-                               tlul_input r_tlul
-                               (output, req) in
-           postc_tlul;
-    |}.
-
-  Lemma incr_invariant_at_reset : invariant_at_reset incr.
-  Proof.
-    simplify_invariant incr.
-    cbn. ssplit; try reflexivity.
-    apply (tlul_adapter_reg_invariant_at_reset (reg_count:=2)).
-  Qed.
-
-  Existing Instance tlul_adapter_reg_correctness.
-
-  (* TODO: move these lemmas to TLUL.v *)
-  Lemma outstanding_in_repr {reg_count : nat} : forall r_tlul t,
-      outstanding_h2d r_tlul = Some t ->
-      In t r_tlul.
-  Proof.
-    intros ? ?.
-    induction r_tlul; intros Houts; cbn in Houts.
-    - discriminate.
-    - destruct (outstanding_h2d r_tlul) eqn:Houts'.
-      + destruct d_ready.
-        * discriminate.
-        * apply in_cons. auto.
-      + destruct (a_valid a).
-        * inversion Houts. apply in_eq.
-        * discriminate.
-  Qed.
-
-  Lemma outstanding_a_valid {reg_count : nat} : forall r_tlul t,
-      outstanding_h2d r_tlul = Some t ->
-      a_valid t = true.
-  Proof.
-    intros ? ?.
-    induction r_tlul; intros Houts; cbn in Houts.
-    - discriminate.
-    - destruct (outstanding_h2d r_tlul) eqn:Houts'.
-      + destruct d_ready.
-        * discriminate.
-        * auto.
-      + destruct (a_valid a) eqn:Hvalid.
-        * inversion Houts. subst. assumption.
-        * discriminate.
-  Qed.
-
-  Lemma outstanding_prec {reg_count : nat} : forall tl_st r_tlul t,
-      tlul_invariant (reg_count:=reg_count) tl_st r_tlul ->
-      outstanding_h2d r_tlul = Some t ->
-      a_opcode t = Get \/ a_opcode t = PutFullData.
-  Proof.
-    intros ? ? ? Hinvar Houts. simpl in *.
-    apply (outstanding_in_repr (reg_count:=reg_count)) in Houts as Hin.
-    unfold tlul_invariant in Hinvar. logical_simplify.
-    eapply Forall_forall in H. 2: apply Hin.
-    apply H.
-    eapply (outstanding_a_valid (reg_count:=reg_count)).
-    apply Houts.
-  Qed.
-
-
-  Lemma incr_invariant_preserved : invariant_preserved incr.
-  Proof.
-    intros (h2d, t) state (((r_state, r_regs), r_tlul), r_inner). destruct t.
-    cbn in * |-. destruct state as ((busy, (done, (registers, d2h))), (tl_st, inner_st)).
-    destruct_tl_h2d. destruct_tl_d2h.
-    intros repr' ? Hinvar Hprec; subst.
-    simplify_invariant incr. logical_simplify. subst.
-    simplify_spec incr. logical_simplify. subst.
-    (* destruct Hprec as [regs Hprec]. *)
-    cbv [incr]. stepsimpl.
-    use_correctness.
-    match goal with
-    | H: (match outstanding_h2d (_::r_tlul) with | _ => _ end) |- _ =>
-      rename H into Htl_postc
-    end.
-    repeat (destruct_pair_let; cbn [fst snd]).
-    ssplit.
-    - eapply tlul_adapter_reg_invariant_preserved.
-      2: apply H.
-      + reflexivity.
-      + assumption.
-    - eapply inner_invariant_preserved.
-      2: apply H0.
-      + simpl in *.
-        destruct r_inner; try reflexivity.
-        destruct (outstanding_h2d r_tlul) eqn:Houts.
-        * destruct d_ready; logical_simplify; subst.
-          -- boolsimpl. destruct r_state; reflexivity.
-          -- eapply outstanding_prec in H as Hprec_t. 2: apply Houts.
-             destruct Hprec_t as [Hprec_t|Hprec_t];
-               rewrite Hprec_t in *; cbn in Htl_postc |- *; logical_simplify; subst;
-                 boolsimpl; destruct r_state; reflexivity.
-        * destruct a_valid eqn:Hvalid; logical_simplify; subst.
-          -- cbn in Htl_postc.
-             match goal with
-             | H: true = true -> _ |- _ =>
-               destruct H; try reflexivity; subst
-             end; cbn in Htl_postc; logical_simplify; subst;
-               boolsimpl; destruct r_state; logical_simplify; subst;
-                 reflexivity.
-          -- boolsimpl; destruct r_state; reflexivity.
-      + match goal with
-        | H: context [_ -> precondition inner _ r_inner] |- _ =>
-          eapply H
-        end.
-        do 8 eexists. ssplit.
-        1-2: reflexivity.
-        apply Htl_postc.
-    - match goal with
-      | H: context [_ -> precondition inner _ r_inner] |- _ => clear H
-      end.
-      destruct r_inner; destruct r_state; destruct inner_st;
-        unfold inner_invariant in H0; logical_simplify; subst;
-          try discriminate;
-          try (destruct H4; discriminate).
-      all: destruct (outstanding_h2d r_tlul) eqn:Houts;
-        cbn [outstanding_h2d] in Htl_postc |- *; rewrite Houts in Htl_postc |- *.
-      all: tlsimpl; destruct d_ready; logical_simplify; subst; boolsimpl.
-      all: cbn; try (ssplit; reflexivity).
-      all: try (eapply outstanding_prec in H;
-                try match goal with
-                    | H: outstanding_h2d _ = Some _ |- outstanding_h2d _ = Some _ =>
-                      apply H
-                    end; destruct H; rewrite H in Htl_postc |- *; cbn in Htl_postc |- *;
-                logical_simplify; subst; ssplit;
-                try (left; reflexivity);
-                try (right; reflexivity);
-                reflexivity).
-      all: try (destruct a_valid; simplify_spec (tlul_adapter_reg (reg_count:=2));
-                tlsimpl; destruct H2;
-                try match goal with
-                    | H: true = true -> _ |- _ =>
-                      destruct H; try reflexivity; subst
-                    end; cbn in Htl_postc; logical_simplify; subst; cbn; ssplit;
-                  try eexists; reflexivity).
-      all: try (destruct a_valid; ssplit;
-                try (left; reflexivity);
-                try (right; reflexivity);
-                reflexivity).
-      all: try (destruct a_valid; simplify_spec (tlul_adapter_reg (reg_count:=2));
-                tlsimpl; destruct H2;
-                try match goal with
-                    | H: true = true -> _ |- _ =>
-                      destruct H; try reflexivity; subst
-                    end; cbn in Htl_postc; logical_simplify; subst;
-                boolsimpl; destruct (negb (N.land a_address 4 =? 0)) eqn:Haddr;
-                cbn; try (rewrite Haddr); ssplit;
-                try (left; reflexivity);
-                try (right; reflexivity);
-                reflexivity).
-      all: (inversion H4; subst; clear H4;
-            destruct x as [|[|[|?]]]; cbn; ssplit;
-            try eexists;
-            try (left; reflexivity);
-            try (right; reflexivity);
-            try reflexivity;
-            exfalso; lia).
-    - match goal with
-      | H: context [_ -> precondition inner _ r_inner] |- _ => clear H
-      end.
-      destruct r_inner; destruct r_state; destruct inner_st;
-        unfold inner_invariant in H0; logical_simplify; subst;
-          try discriminate.
-      all: destruct (outstanding_h2d r_tlul) eqn:Houts;
-        cbn [outstanding_h2d] in Htl_postc |- *; rewrite Houts in Htl_postc |- *.
-      all: tlsimpl; destruct d_ready; logical_simplify; subst; boolsimpl.
-      all: try reflexivity.
-      all: try (eapply outstanding_prec in H;
-                try match goal with
-                    | H: outstanding_h2d _ = Some _ |- outstanding_h2d _ = Some _ =>
-                      apply H
-                    end; destruct H; rewrite H in Htl_postc |- *; cbn in Htl_postc |- *;
-                logical_simplify; subst; cbn; reflexivity).
-      all: try (destruct a_valid; simplify_spec (tlul_adapter_reg (reg_count:=2));
-                tlsimpl; destruct H2;
-                try match goal with
-                    | H: true = true -> _ |- _ =>
-                      destruct H; try reflexivity; subst
-                    end; cbn in Htl_postc; logical_simplify; subst; reflexivity).
-      all: try (destruct a_valid; simplify_spec (tlul_adapter_reg (reg_count:=2));
-                tlsimpl; destruct H2;
-                try match goal with
-                    | H: true = true -> _ |- _ =>
-                      destruct H; try reflexivity; subst
-                    end; cbn in Htl_postc; logical_simplify; subst;
-                boolsimpl; destruct (negb (N.land a_address 4 =? 0)) eqn:Haddr;
-                cbn; try (rewrite Haddr); reflexivity).
-      all: try (inversion H4; subst; clear H4;
-            destruct x as [|[|[|?]]]; try reflexivity; exfalso; lia).
-      all: try (destruct H4; discriminate).
-  Qed.
-
-  Lemma incr_output_correct : output_correct incr.
-  Proof.
-    intros (h2d, t) state (((r_state, r_regs), r_tlul), r_inner). destruct t.
-    cbn in * |-. destruct state as ((busy, (done, (registers, d2h))), (tl_st, inner_st)).
-    destruct_tl_h2d. destruct_tl_d2h.
-    intros Hinvar Hprec; subst.
-    simplify_invariant incr. logical_simplify. subst.
-    simplify_spec incr. logical_simplify. subst.
-    cbv [incr]. stepsimpl.
-    use_correctness.
-    match goal with
-    | H: (match outstanding_h2d (_::r_tlul) with | _ => _ end) |- _ =>
-      rename H into Htl_postc
-    end.
-    repeat (destruct_pair_let; cbn [fst snd]).
-    tlsimpl.
-    destruct r_inner; destruct r_state; destruct inner_st;
-      unfold inner_invariant in H0; logical_simplify; subst;
-        try discriminate;
-        try (destruct H5; discriminate).
-    all: destruct (outstanding_h2d r_tlul) eqn:Houts;
-      cbn [outstanding_h2d] in Htl_postc |- *; rewrite Houts in Htl_postc |- *.
-    all: tlsimpl; destruct d_ready; logical_simplify; subst; boolsimpl.
-    all: do 9 eexists.
-    all: ssplit; try reflexivity; tlsimpl; ssplit; try reflexivity; try assumption.
-    all: try (eapply outstanding_prec in H;
-              try match goal with
-                  | H: outstanding_h2d _ = Some _ |- outstanding_h2d _ = Some _ =>
-                    apply H
-                  end; destruct H; rewrite H in Htl_postc |- *; cbn in Htl_postc |- *;
-              logical_simplify; subst; ssplit;
-              try (left; reflexivity);
-              try (right; reflexivity);
-              try assumption;
-              reflexivity).
-    all: try (destruct a_valid; simplify_spec (tlul_adapter_reg (reg_count:=2));
-              tlsimpl; destruct H2;
-              try match goal with
-                  | H: true = true -> _ |- _ =>
-                    destruct H; try reflexivity; subst
-                  end; cbn in Htl_postc; logical_simplify; subst; cbn; ssplit;
-              try eexists; try assumption; reflexivity).
-    Unshelve. all: auto.
-  Qed.
-
-  Existing Instances incr_invariant_at_reset incr_invariant_preserved
-           incr_output_correct.
-  Global Instance incr_correctness : correctness_for incr.
-  Proof. constructor; typeclasses eauto. Defined.
-End Spec.
-
-Require Import Coq.micromega.Lia.
+Require Import coqutil.Word.Interface coqutil.Word.Properties.
 
 Require Import riscv.Utility.Utility.
-
-Require Import coqutil.Map.Interface coqutil.Map.Properties.
-Require Import coqutil.Word.Interface coqutil.Word.Properties.
-Require Import coqutil.Tactics.Tactics.
-Require Import coqutil.Tactics.Simp.
-Require Import coqutil.Tactics.fwd.
 
 Require Import bedrock2.ZnWords.
 
 Require Import Bedrock2Experiments.RiscvMachineWithCavaDevice.InternalMMIOMachine.
 Require Import Bedrock2Experiments.IncrementWait.Constants.
+Require Import Bedrock2Experiments.IncrementWait.Incr.
 Require Import Bedrock2Experiments.IncrementWait.IncrementWaitSemantics.
 Require Import Bedrock2Experiments.StateMachineSemantics.
 Require Import Bedrock2Experiments.RiscvMachineWithCavaDevice.MMIOToCava.
 
-Require Import Cava.Util.Tactics.
+Import ListNotations.
 
 Section WithParameters.
   Instance var : tvar := denote_type.
@@ -647,32 +37,10 @@ Section WithParameters.
   Context {word: Interface.word 32} {word_ok: word.ok word}
           {Mem: map.map word byte} {Registers: map.map Z word}.
 
-  Definition consistent_states
-             '((reqid, (reqsz, (rspop, (error, (outstanding, (_we_o, _re_o))))))
-               : denote_type (state_of (tlul_adapter_reg (reg_count := 2))))
-             '((d_valid, (d_opcode, (d_param, (d_size, (d_source, (d_sink, (d_data, (d_user, (d_error, a_ready)))))))))
-               : denote_type tl_d2h_t)
-    : Prop :=
-      d_valid = outstanding /\
-      d_opcode = rspop /\
-      (* d_param = 0 /\ *)
-      d_size = reqsz /\
-      d_source = reqid /\
-      (* d_sink = 0 /\ *)
-      (* d_data = ?? *)
-      (* d_user = 0 /\ *)
-      d_error = error /\
-      a_ready = negb outstanding.
-
-  Definition mk_counter_state (istate : N) (val : N) tl_d2h tlul_state
-    : denote_type (state_of incr) :=
-    ((istate, (val, tl_d2h)), tlul_state).
-
   Global Instance counter_device: device := {|
     device.state := denote_type (state_of incr);
-    device.is_ready_state s := exists val tl_d2h tlul_state,
-        consistent_states tlul_state tl_d2h
-        /\ s = mk_counter_state 0 val tl_d2h tlul_state;
+    device.is_ready_state s := exists r_regs r_tlul r_inner,
+        incr_invariant s (RSIdle, r_regs, r_tlul, r_inner);
     device.run1 s i := Semantics.step incr s (i, tt);
     device.addr_range_start := INCR_BASE_ADDR;
     device.addr_range_pastend := INCR_END_ADDR;
@@ -687,27 +55,26 @@ Section WithParameters.
   Global Instance circuit_spec : circuit_behavior :=
   {| ncycles_processing := 15%nat |}.
 
-  Inductive counter_related: IncrementWaitSemantics.state -> denote_type (state_of incr) -> Prop :=
-  | IDLE_related: forall val tl_d2h tlul_state,
-      consistent_states tlul_state tl_d2h ->
-      counter_related IDLE (mk_counter_state 0 val tl_d2h tlul_state)
-  | BUSY1_related: forall val tl_d2h tlul_state ncycles,
-      (1 < ncycles)%nat ->
-      consistent_states tlul_state tl_d2h ->
-      counter_related (BUSY val ncycles) (mk_counter_state 1 (word_to_N val) tl_d2h tlul_state)
-  | BUSY2_related: forall val tl_d2h tlul_state ncycles,
+  Inductive counter_related_spec: IncrementWaitSemantics.state -> repr -> Prop :=
+  | IDLE_related: forall r_regs r_tl r_inner,
+      counter_related_spec IDLE (RSIdle, r_regs, r_tl, r_inner)
+  | BUSY_related: forall r_regs r_tl r_inner val ncycles,
       (0 < ncycles)%nat ->
-      consistent_states tlul_state tl_d2h ->
-      counter_related (BUSY val ncycles) (mk_counter_state 2 (word_to_N val) tl_d2h tlul_state)
+      counter_related_spec (BUSY val ncycles)
+                           (RSBusy (word_to_N val), r_regs, r_tl, r_inner)
   (* the hardware is already done, but the software hasn't polled it yet to find out,
      so we have to relate a software-BUSY to a hardware-done: *)
-  | BUSY_done_related: forall val tl_d2h tlul_state ncycles,
-      consistent_states tlul_state tl_d2h ->
-      counter_related (BUSY val ncycles)
-                      (mk_counter_state 3 (word_to_N (word.add (word.of_Z 1) val)) tl_d2h tlul_state)
-  | DONE_related: forall val tl_d2h tlul_state,
-      consistent_states tlul_state tl_d2h ->
-      counter_related (DONE val) (mk_counter_state 3 (word_to_N val) tl_d2h tlul_state).
+  | BUSY_done_related: forall r_regs r_tl r_inner val ncycles,
+      counter_related_spec (BUSY val ncycles)
+                           (RSDone (word_to_N (word.add (word.of_Z 1) val)), r_regs, r_tl, r_inner)
+  | DONE_related: forall r_regs r_tl r_inner val,
+      nth 0 r_regs 0%N = (word_to_N val)
+      -> counter_related_spec (DONE val)
+                             (RSDone (word_to_N val), r_regs, r_tl, r_inner).
+
+  Definition counter_related (sH : IncrementWaitSemantics.state)
+             (sL : denote_type (state_of incr)) : Prop :=
+    exists repr, counter_related_spec sH repr /\ incr_invariant sL repr.
 
   (* This should be in bedrock2.ZnWords. It is use by ZnWords, which is used in
      the two following Lemmas. *)
@@ -737,198 +104,365 @@ Section WithParameters.
       eapply pair_equal_spec in H; destruct H as [?H0 ?H1]
     end.
 
-  Ltac destruct_tlul_adapter_reg_state :=
-    match goal with
-    | H : N * (N * (N * (bool * (bool * (bool * bool))))) |- _ =>
-      destruct H as [?reqid [?reqsz [?rspop [?error [?outstanding [?we_o ?re_o]]]]]]
-    end.
-
-  Ltac destruct_consistent_states :=
-    match goal with
-    | H : consistent_states _ _ |- _ =>
-      destruct H as (Hvalid & Hopcode & Hsize & Hsource & Herror & Hready)
-    end.
+  (* Ltac destruct_tlul_adapter_reg_state := *)
+  (*   match goal with *)
+  (*   | H : N * (N * (N * (bool * (bool * (bool * bool))))) |- _ => *)
+  (*     destruct H as [?reqid [?reqsz [?rspop [?error [?outstanding [?we_o ?re_o]]]]]] *)
+  (*   end. *)
 
   Lemma N_to_word_word_to_N: forall v, N_to_word (word_to_N v) = v.
   Proof. intros. unfold N_to_word, word_to_N. ZnWords. Qed.
 
-(* TODO move to coqutil *)
-Ltac contradictory H :=
-  lazymatch type of H with
-  | ?x <> ?x => exfalso; apply (H eq_refl)
-  | False => case H
-  end.
-Require Import coqutil.Tactics.autoforward.
-Ltac fwd_step ::=
-  match goal with
-  | H: ?T |- _ => is_destructible_and T; destr_and H
-  | H: exists y, _ |- _ => let yf := fresh y in destruct H as [yf H]
-  | H: ?x = ?x |- _ => clear H
-  | H: True |- _ => clear H
-  | H: ?LHS = ?RHS |- _ =>
-    let h1 := head_of_app LHS in is_constructor h1;
-    let h2 := head_of_app RHS in is_constructor h2;
-    (* if not eq, H is a contradiction, but we don't want to change the number
-       of open goals in this tactic *)
-    constr_eq h1 h2;
-    (* we don't use `inversion H` or `injection H` because they unfold definitions *)
-    inv_rec LHS RHS;
-    clear H
-  | E: ?x = ?RHS |- context[match ?x with _ => _ end] =>
-    let h := head_of_app RHS in is_constructor h; rewrite E in *
-  | H: context[match ?x with _ => _ end], E: ?x = ?RHS |- _ =>
-    let h := head_of_app RHS in is_constructor h; rewrite E in *
-  | H: context[match ?x with _ => _ end] |- _ =>
-    (* note: recursive invocation of fwd_step for contradictory cases *)
-    destr x; try solve [repeat fwd_step; contradictory H]; []
-  | H: _ |- _ => autoforward with typeclass_instances in H
-  | |- _ => progress subst
-  | |- _ => progress fwd_rewrites
-  end.
+  Existing Instance Incr.inner_specification.
+  Existing Instance Incr.inner_correctness.
+  Existing Instance Incr.inner_invariant.
 
-  Axiom TODO: False.
+  Existing Instance TLUL.tlul_specification.
+  Existing Instance TLUL.tlul_adapter_reg_correctness.
+  Existing Instance TLUL.tlul_invariant.
+
+  Existing Instance incr_specification.
+  Existing Instance incr_correctness.
+
+  Lemma runUntilResp_big_step : forall s h2d repr,
+      precondition incr (h2d, tt) repr
+      -> a_valid h2d = true
+      -> d_ready h2d = true (* TODO: do we need this? *)
+      -> incr_invariant s repr
+      -> exists n inputs s' repr' d2h s'',
+          device.runUntilResp h2d device.maxRespDelay s = (Some d2h, s'')
+          /\ n <= device.maxRespDelay
+          /\ inputs = repeat (h2d, tt) n
+          /\ s' = snd (simulate' incr inputs s)
+          (* /\ (s'', d2h) = Semantics.step incr s' (h2d, tt) *)
+          /\ repr' = fold_left (fun r i => update_repr (c:=incr) i r) inputs repr
+          (* /\ invariant s' repr' *)
+          /\ postcondition incr (h2d, tt) repr' d2h
+          /\ d_valid d2h = true
+          /\ incr_invariant s'' (update_repr (c:=incr) (h2d, tt) repr').
+  Proof.
+    intros ? ? ? Hprec Ea_valid Ed_ready Hinv.
+    unfold device.maxRespDelay, device.runUntilResp, device.state, device.run1, counter_device,
+    state_machine.read_step, increment_wait_state_machine, read_step in *.
+    eapply output_correct_pf in Hinv as Houtput.
+    apply Houtput in Hprec as Hpostc. clear Houtput.
+    cbn in s, h2d. destruct_tl_h2d.
+    destruct repr as (((?r_state, ?r_regs), ?r_tl), ?r_inner).
+    assert (Hprec_temp := Hprec).
+    unfold precondition, incr_specification in Hprec_temp.
+    logical_simplify.
+    unfold precondition, tlul_specification in H.
+    logical_simplify. tlsimpl. subst.
+    unfold postcondition, incr_specification in Hpostc.
+    unfold postcondition, tlul_specification in Hpostc.
+    destruct Hpostc as [[is_read [is_write [address [w_val w_mask]]]] [h2d' [regs' [d2h' [is_read' [is_write' [address' [w_val' [w_mask' Hpostc]]]]]]]]].
+    destruct_tl_h2d. destruct_tl_d2h. tlsimpl.
+    destruct Hpostc as [Hpostc1 [Hpostc2 Hpostc3]].
+    subst.
+    apply pair_equal_spec in Hpostc2.
+    logical_simplify.
+    cbn [outstanding_h2d] in Hpostc3.
+    destruct (outstanding_h2d r_tl) eqn:Eouts.
+    - cbn in Hpostc3. logical_simplify. subst.
+      assert (Hprec':
+                precondition incr
+                             (true,
+                              (a_opcode0,
+                               (a_param0, (a_size0, (a_source0, (a_address, (a_mask0, (a_data0, (a_user0, true)))))))), tt)
+                             (update_repr (c:=incr)
+                                          (true,
+                                           (a_opcode0,
+                                            (a_param0, (a_size0, (a_source0, (a_address, (a_mask0, (a_data0, (a_user0, true)))))))), tt)
+                                          (r_state, regs', r_tl, r_inner))).
+      { simplify_spec incr.
+        cbn [outstanding_h2d]. rewrite Eouts.
+        tlsimpl. ssplit.
+        - simplify_spec (tlul_adapter_reg (reg_count:=2)). tlsimpl. split; [|assumption].
+          match goal with
+          | |- context [length (match ?m with | _=> _ end)] =>
+            destruct m
+          end;
+          match goal with
+          | |- context [replace _ _ (match ?m with | _=> _ end)] =>
+            destruct m
+          end; rewrite ! length_replace; assumption.
+        - simplify_spec Incr.inner. intros. apply I.
+      }
+      destruct H1; [auto|..]; subst.
+      all: exists 1.
+      all: destruct_pair_let;
+        match goal with
+        | |- context [if d_valid ?c then _ else _] =>
+          match type of H2 with
+          | _ = ?r => replace c with r
+          end
+        end.
+      all: tlsimpl;
+        assert (Hinv' := Hprec);
+        eapply incr_invariant_preserved in Hinv;
+        [apply Hinv in Hinv'|reflexivity]; clear Hinv.
+      all: eapply output_correct_pf in Hinv' as Houtput';
+        apply Houtput' in Hprec' as Hpostc'; clear Houtput';
+          assert (Hpostc'' := Hpostc');
+        unfold postcondition, incr_specification in Hpostc';
+        unfold postcondition, tlul_specification in Hpostc';
+        cbn [update_repr outstanding_h2d] in Hpostc';
+        rewrite Eouts in Hpostc'; cbn -[Semantics.step] in Hpostc';
+        destruct Hpostc' as [[is_read [is_write [address [w_val w_mask]]]] [h2d' [regs'' [d2h' [is_read' [is_write' [address'' [w_val'' [w_mask'' Hpostc']]]]]]]]].
+      all: destruct_tl_h2d; destruct_tl_d2h; tlsimpl;
+        destruct Hpostc' as [Hpostc1' [Hpostc2' Hpostc3']];
+        subst;
+        apply pair_equal_spec in Hpostc2';
+        logical_simplify;
+        rewrite Eouts in Hpostc3';
+        tlsimpl.
+      all: cbn in Hpostc3'; logical_simplify; subst.
+      all: do 5 eexists; ssplit; try reflexivity.
+      1,5: destruct_pair_let;
+                match goal with
+        | |- context [if d_valid ?c then _ else _] =>
+          match type of H1 with
+          | _ = ?r => replace c with r
+          end
+        end; tlsimpl; reflexivity.
+      1,4: cbn [repeat fold_left];
+        match goal with
+        | H: postcondition incr _ _ ?c |- _ =>
+          match type of H1 with
+          | _ = ?r => replace c with r in H; apply H
+          end
+        end.
+      1,3: reflexivity.
+      1,2: cbn [repeat fold_left];
+        eapply incr_invariant_preserved; [reflexivity|assumption..].
+    - destruct H1; [auto|..]; subst; cbn in Hpostc3; logical_simplify; subst.
+      all: exists 0.
+      all: do 5 eexists; ssplit; try reflexivity; try lia.
+      1,5: destruct_pair_let;
+        match goal with
+        | |- context [if d_valid ?c then _ else _] =>
+          match type of H2 with
+          | _ = ?r => replace c with r
+          end
+        end; tlsimpl; reflexivity.
+      1,4: cbn [repeat fold_left];
+        eapply output_correct_pf in Hinv as Houtput;
+        apply Houtput in Hprec;
+        match goal with
+        | H: postcondition incr _ _ ?c |- _ =>
+          match type of H2 with
+          | _ = ?r => replace c with r in H; apply H
+          end
+        end.
+      1,3: reflexivity.
+      1,2: cbn [repeat fold_left];
+        eapply incr_invariant_preserved; [reflexivity|assumption..].
+  Qed.
 
   (* Set Printing All. *)
   Global Instance cava_counter_satisfies_state_machine:
     device_implements_state_machine counter_device increment_wait_state_machine.
   Proof.
-    eapply Build_device_implements_state_machine with (device_state_related := counter_related);
-      intros.
+    eapply Build_device_implements_state_machine with (device_state_related := counter_related).
     - (* mmioAddrs_match: *)
       reflexivity.
     - (* initial_state_is_ready_state: *)
-      simpl in *. subst. inversion H0. subst. eexists _, _, _. eauto.
+      intros ? ? Hinit Hrel.
+      cbn in *. subst. destruct Hrel as [?repr [?Hrel ?Hinv]].
+      inversion Hrel. subst.
+      do 3 eexists. eapply Hinv.
     - (* initial_states_are_related: *)
-      simpl in *. destruct H0 as (val & tl_d2h & tlul_state & H0 & H1). subst.
-      eauto using IDLE_related.
+      intros ? ? Hinit Hready.
+      cbn in *. destruct Hready as (?r_regs & ?r_tl & ?r_inner & ?Hinv). subst.
+      unfold counter_related. eexists. split; [|apply Hinv].
+      apply IDLE_related.
     - (* initial_state_exists: *)
-      simpl in *. destruct H as (val & tl_d2h & tlul_state & H0 & H1). subst.
-      eauto using IDLE_related.
+      intros ? Hready.
+      cbn in *. destruct Hready as (?r_regs & ?r_tl & ?r_inner & ?Hinv).
+      eexists. split; [reflexivity|].
+      unfold counter_related. eexists. split; [|apply Hinv].
+      apply IDLE_related.
     - (* nonMMIO_device_step_preserves_state_machine_state: *)
-      simpl in sL1, sL2.
-      destruct_tl_h2d. simpl in H. subst.
-      cbn in H1.
-      repeat (destruct_pair_let_hyp;
-              repeat (destruct_pair_equal_hyp; subst; cbn [fst snd])).
-      inversion H0; subst;
+      intros ? ? ? ? ? Ha_valid Hrel.
+      (* cbn in sL1, sL2. *)
+      (* destruct sL2 as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner)). *)
+      (* destruct_tl_h2d. destruct_tl_d2h. tlsimpl. subst. *)
+      unfold device.run1. unfold counter_device.
+      intros Hstep.
+      destruct Hrel as [?repr [?Hrel ?Hinv]].
+      assert (Hprec: precondition incr (h2d, tt) repr).
+      { destruct_tl_h2d. destruct_tl_d2h. tlsimpl.
+        cbn in sL1; destruct sL1 as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner)).
+        destruct repr as (((?r_state, ?r_regs), ?r_tl), ?r_inner).
+        simplify_invariant incr. logical_simplify.
+        subst. cbn. ssplit.
+        - auto.
+        - intros. discriminate.
+        - intros. auto.
+      }
+      eapply incr_invariant_preserved in Hinv as Hinv'; [|reflexivity].
+      unfold counter_related. exists (update_repr (c:=incr) (h2d, tt) repr).
+      rewrite surjective_pairing with (A:=counter_device) (B:=tl_d2h)
+                                      (p:=Semantics.step incr sL1 (h2d, tt)) in Hstep.
+      apply pair_equal_spec in Hstep. destruct Hstep as [Hstep1 Hstep2]. subst.
+      split; [| apply Hinv'; apply Hprec].
+      inversion Hrel; subst;
+        destruct_tl_h2d; destruct_tl_d2h; tlsimpl; subst;
+          cbn in sL1; destruct sL1 as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner));
+            simplify_invariant incr; logical_simplify; subst;
+              cbn -[replace].
+      all: try (destruct x as [|[|[|]]]);
+        destruct (outstanding_h2d r_tl), d_ready;
+        try destruct (TLUL.a_opcode t =? Get)%N, (TLUL.a_opcode t =? PutFullData)%N;
         try (rewrite incrN_word_to_bv);
-        try (constructor; try lia; simpl; boolsimpl; ssplit; reflexivity).
-    - (* state_machine_read_to_device_read_or_later: *)
-      case TODO.
-      (*
-      cbn [counter_device device.state device.is_ready_state device.run1 device.addr_range_start
-           device.addr_range_pastend device.maxRespDelay] in *.
-      cbn [increment_wait_state_machine
-             state_machine.state
-             state_machine.register
-             state_machine.is_initial_state
-             state_machine.read_step
-             state_machine.write_step
-             state_machine.reg_addr
-             state_machine.isMMIOAddr] in *.
-      simpl in sL. destruct sL as ((istate & value & tl_d2h) & tlul_state).
-      destruct_tl_d2h. destruct_tlul_adapter_reg_state.
-      destruct H as [v [sH' [Hbytes H]]]. rewrite Hbytes.
-      tlsimpl.
-      destruct r; simp.
+        boolsimpl; constructor; try assumption.
+      all: destruct H6; subst; destruct r_regs; cbn in H |- *; assumption.
+    - (* state_machine_read_to_device_read: *)
+      (* simpler because device.maxRespDelay=1 *)
+      intros ? ? ? ? [v [sH'' Hex_read]] [repr Hrel].
+      cbn in Hex_read. logical_simplify. rewrite  H1.
+      unfold counter_related.
+      match goal with
+      | |- context [ device.runUntilResp ?x _ _ ] =>
+        remember x as h2d eqn:Eh2d; replace x with h2d
+      end.
+      assert (Hprec: precondition incr (h2d, tt) repr).
+      { destruct_tl_h2d. tlsimpl.
+        cbn in sL; destruct sL as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner)).
+        destruct repr as (((?r_state, ?r_regs), ?r_tl), ?r_inner).
+        simplify_invariant incr. logical_simplify.
+        subst. cbn. ssplit; intros; auto.
+      }
+      pose (r_ := r). destruct r.
       + (* r=VALUE *)
-        destruct_tl_h2d.
-        cbn in *. subst.
-
-        destruct_consistent_states. subst.
-        destruct outstanding; cbn in H1|-*; fwd.
-
-
-          eexists _, _, _; ssplit; try reflexivity; cbn; rewrite Z_word_N by lia;
-            try (eapply IDLE_related; unfold consistent_states; ssplit; reflexivity);
-            try (apply N_to_word_word_to_N).
+        pose (sH_ := sH); destruct sH; cbn in H2; try (exfalso; assumption); logical_simplify; subst.
+        inversion H; subst.
+        eapply runUntilResp_big_step with (s:=sL) in Hprec
+          as [n [inputs [sL' [repr' [d2h [sL'' [HrunU [HmaxRespDelay [Einputs [EsL' [Erepr' [Hpostc' [Ed_valid Hinv'']]]]]]]]]]]]]; subst; auto.
+        exists d2h, sL'', IDLE.
+        ssplit.
+        3: cbn; ssplit; try reflexivity; [].
+        * assumption.
+        * eexists.
+          split; [|apply Hinv''].
+          simplify_invariant incr.
+          simplify_invariant Incr.inner.
+          simplify_invariant (tlul_adapter_reg (reg_count:=2)).
+          cbn in sL''; destruct sL'' as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner)).
+          clear HrunU.
+          pose (n_:=n). destruct n as [|[|n]].
+          3: unfold device.maxRespDelay, counter_device in HmaxRespDelay; exfalso; lia.
+          all: cbn [repeat fold_left] in *.
+          -- destruct Hpostc' as [req' [h2d' [regs' [d2h' [io_re' [io_we' [io_address' [io_data' [io_mask' Hpostc']]]]]]]]].
+             logical_simplify.
+             cbn in H5.
+             destruct (outstanding_h2d r_tl) eqn:Houts.
+             ++ logical_simplify. rewrite Ed_valid in * |-. discriminate.
+             ++ cbn in H5. logical_simplify.
+                destruct_tl_d2h. tlsimpl. subst.
+                simplify_invariant incr.
+                cbn in sL; destruct sL as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner)).
+                cbn in Hinv'' |- *.
+                rewrite Houts in Hinv'' |- *. cbn in Hinv''. logical_simplify.
+                cbn in *.
+                logical_simplify. subst.
+                rewrite Z_word_N in * by lia. cbn in *. logical_simplify. subst.
+                apply IDLE_related.
+          -- cbn in Hpostc'.
+             destruct (outstanding_h2d r_tl) eqn:Houts;
+             destruct Hpostc' as [req' [h2d' [regs' [d2h' [io_re' [io_we' [io_address' [io_data' [io_mask' Hpostc']]]]]]]]];
+             logical_simplify;
+             cbn in H5; rewrite Houts in H5; cbn in H5; logical_simplify; subst.
+             ++ destruct_tl_d2h. tlsimpl. subst.
+                simplify_invariant incr.
+                cbn in sL; destruct sL as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner)).
+                cbn in Hinv'' |- *.
+                rewrite Houts in Hinv'' |- *. cbn in Hinv'' |- *. logical_simplify.
+                rewrite Houts. cbn.
+                rewrite Z_word_N in * by lia. cbn in *.
+                destruct H8; subst; apply IDLE_related.
+             ++ rewrite Ed_valid in * |-. discriminate.
+        * pose (n_:=n). destruct n as [|[|n]].
+          -- cbn [repeat fold_left] in *.
+             destruct Hpostc' as [req' [h2d' [regs' [d2h' [io_re' [io_we' [io_address' [io_data' [io_mask' Hpostc']]]]]]]]].
+             logical_simplify.
+             cbn in H5.
+             destruct (outstanding_h2d r_tl) eqn:Houts.
+             ++ logical_simplify. rewrite Ed_valid in * |-. discriminate.
+             ++ cbn in H5. logical_simplify.
+                destruct_tl_d2h. tlsimpl. subst.
+                simplify_invariant incr.
+                cbn in sL; destruct sL as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner)).
+                cbn in sL''; destruct sL'' as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner)).
+                cbn in Hinv''.
+                rewrite Houts in Hinv''. cbn in Hinv''. logical_simplify.
+                cbn in *.
+                logical_simplify. subst.
+                rewrite Z_word_N in * by lia. cbn in *. logical_simplify. subst.
+                rewrite H3. apply N_to_word_word_to_N.
+          -- cbn [repeat fold_left] in *.
+             cbn in Hpostc'.
+             destruct (outstanding_h2d r_tl) eqn:Houts;
+             destruct Hpostc' as [req' [h2d' [regs' [d2h' [io_re' [io_we' [io_address' [io_data' [io_mask' Hpostc']]]]]]]]];
+             logical_simplify;
+             cbn in H5; rewrite Houts in H5; cbn in H5; logical_simplify; subst.
+             ++ destruct_tl_d2h. tlsimpl. subst.
+                simplify_invariant incr.
+                cbn in sL; destruct sL as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner)).
+                cbn in sL''; destruct sL'' as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner)).
+                cbn in Hinv''.
+                rewrite Houts in Hinv''. cbn in Hinv''. logical_simplify.
+                rewrite Z_word_N in * by lia. cbn -[replace] in *.
+                destruct H8; subst; destruct r_regs; cbn in H3 |- *;
+                  rewrite H3; apply N_to_word_word_to_N.
+             ++ rewrite Ed_valid in * |-. discriminate.
+          -- unfold device.maxRespDelay, counter_device in HmaxRespDelay. exfalso. lia.
       + (* r=STATUS *)
-        destruct sH; [| |].
-        * (* sH=IDLE *)
-          inversion H0. subst.
-          destruct_consistent_states. subst. cbn.
-          repeat (rewrite Z_word_N by lia; cbn).
-          unfold status_value, STATUS_IDLE, N_to_word, word_to_N.
-          destruct outstanding; eexists _, _, _; ssplit; try reflexivity;
-              try (apply IDLE_related; simpl; ssplit; reflexivity);
-              try (simpl; unfold N_to_word; ZnWords).
-        * (* sH=BUSY *)
-          simpl.
-          unfold STATUS_ADDR, INCR_BASE_ADDR, N_to_word, word_to_N, status_value, STATUS_BUSY.
-          rewrite word.unsigned_of_Z. unfold word.wrap.
-          inversion H0; subst; [| |].
-          -- (* BUSY1_related *)
-            destruct outstanding; eexists _, _, _; simpl; [|].
-            ++ ssplit; try reflexivity; [|].
-               ** rewrite incrN_word_to_bv.
-                  apply BUSY_done_related; unfold consistent_states; ssplit; reflexivity.
-               ** right. eexists. ssplit; try reflexivity; [|].
-                  --- apply Nat.pred_inj; try lia. rewrite Nat.pred_succ. reflexivity.
-                  --- simpl. ZnWords.
-            ++ ssplit; try reflexivity; [|].
-               ** apply BUSY2_related. 1: shelve. unfold consistent_states. ssplit; reflexivity.
-               ** right. eexists. ssplit; try reflexivity; [|].
-                  --- apply Nat.pred_inj; try lia. rewrite Nat.pred_succ. reflexivity.
-                  --- simpl. ZnWords.
-                      Unshelve. lia.
-          -- (* BUSY2_related *)
-            destruct outstanding; eexists _, _, _; simpl; [|].
-            ++ ssplit; try reflexivity; [|].
-              ** rewrite incrN_word_to_bv.
-                 apply DONE_related; unfold consistent_states; ssplit; reflexivity.
-              ** left. simpl. ssplit; try reflexivity. ZnWords.
-            ++ ssplit; try reflexivity; [|].
-              ** rewrite incrN_word_to_bv.
-                 apply BUSY_done_related; unfold consistent_states; ssplit; reflexivity.
-              ** right. eexists. ssplit; try reflexivity; [|].
-                 --- apply Nat.pred_inj; try lia. rewrite Nat.pred_succ. reflexivity.
-                 --- simpl. ZnWords.
-          -- (* BUSY_done_related *)
-            (* the transition that was used to show that sH is not stuck was *)
-            (* a transition from BUSY to BUSY returning a busy flag, but *)
-            (* since the device already is in done state, it will return a *)
-            (* done flag in this transition, so the transition we use to *)
-            (* simulate what happened in the device is a BUSY-to-DONE *)
-            (* transition returning a done flag instead of a BUSY-to-BUSY *)
-            (* transition returning a busy flag. *)
-            destruct outstanding; eexists _, _, _; boolsimpl; simpl;
-              ssplit; try reflexivity;
-                try (apply DONE_related; unfold consistent_states; ssplit; reflexivity);
-                try (left; split; try reflexivity; simpl; ZnWords).
-        * (* sH=DONE *)
-          simpl.
-          unfold STATUS_ADDR, INCR_BASE_ADDR, N_to_word, word_to_N, status_value, STATUS_BUSY.
-          rewrite !word.unsigned_of_Z. unfold word.wrap.
-          inversion H0. subst.
-          destruct outstanding; eexists _, _, _; boolsimpl; simpl;
-            ssplit; try reflexivity;
-              try (eapply DONE_related; unfold consistent_states; ssplit; reflexivity);
-              try (simpl; ZnWords).
-      *)
-    - (* state_machine_write_to_device_write_or_later: *)
-      case TODO.
-      (*
-      destruct H as (sH' & ? & ?). subst.
-      unfold write_step in H1.
-      destruct r. 2: contradiction.
-      destruct sH; try contradiction. subst.
-      inversion H0. simpl in tl_d2h. simpl in tlul_state.
-      destruct_tl_d2h. destruct_tlul_adapter_reg_state. subst. cbn.
-      unfold word_to_N.
-      rewrite word.unsigned_of_Z_nowrap by (cbv; intuition discriminate).
-      destruct outstanding; boolsimpl; simpl;
-        eexists _, _, _; ssplit; try reflexivity; try assumption; apply BUSY1_related;
-          try lia;
-          try (unfold consistent_states; ssplit; reflexivity).
-      *)
+        eapply runUntilResp_big_step in Hprec as [n [inputs [sL' [repr' [d2h [sL'' [HrunU [HmaxRespDelay [Einputs [EsL' [Erepr' [Hpostc' [Ed_valid Hinv'']]]]]]]]]]]]]; subst; auto; [|eassumption].
+        inversion H; subst.
+        * do 3 eexists; ssplit.
+          -- rewrite HrunU; reflexivity.
+          -- eexists; split; [|eassumption];
+               destruct n as [|[|n]];
+               [| |unfold device.maxRespDelay, counter_device in HmaxRespDelay; exfalso; lia];
+               cbn [repeat fold_left] in *;
+               simplify_invariant incr;
+               cbn in sL; destruct sL as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner));
+                 logical_simplify; subst;
+                   cbn; destruct (outstanding_h2d r_tl) eqn:Eouts;
+                     try (cbn; rewrite Eouts; cbn);
+                     apply IDLE_related.
+          -- cbn. ssplit; try reflexivity.
+             destruct n as [|[|n]];
+               [| |unfold device.maxRespDelay, counter_device in HmaxRespDelay; exfalso; lia];
+               cbn [repeat fold_left] in *; simplify_spec incr;
+                 simplify_spec (tlul_adapter_reg (reg_count:=2)).
+             ++ destruct Hpostc' as [req' [h2d' [regs' [d2h' [io_re' [io_we' [io_address' [io_data' [io_mask' Hpostc']]]]]]]]]; logical_simplify; cbn in H5;
+                  destruct (outstanding_h2d r_tl) eqn:Eouts;
+                  [logical_simplify; rewrite Ed_valid in *; discriminate|];
+                  cbn in H5; logical_simplify; rewrite H9.
+                unfold status_value, STATUS_IDLE, N_to_word, word_to_N.
+                simplify_invariant incr.
+                cbn in sL; destruct sL as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner)).
+                logical_simplify.
+                replace (N.to_nat ((N.land (Z.to_N (word.unsigned (word.of_Z 16388))) 4 / 4) mod 1073741824)) with 1.
+                ** ZnWords.
+                ** ZnWords_pre. rewrite Zmod_small; [|lia].
+                   rewrite N.mod_small; cbn; lia.
+             ++ admit.
+        * admit.
+        * admit.
+        * admit.
+    - (* state_machine_write_to_device_write: *)
+      admit.
     - (* read_step_unique: *)
-      simpl in *. unfold read_step in *. simp.
+      intros. simpl in *. unfold read_step in *. simp.
       destruct v; destruct r; try contradiction; simp; try reflexivity.
       destruct Hp1; destruct H0p1; simp; try reflexivity;
         unfold status_value in *; exfalso; ZnWords.
     - (* write_step_unique: *)
-      simpl in *. unfold write_step in *. simp. subst. reflexivity.
+      intros. simpl in *. unfold write_step in *. simp. subst. reflexivity.
     - (* initial_state_unique: *)
-      simpl in *. subst. reflexivity.
+      intros. simpl in *. subst. reflexivity.
   Qed.
 End WithParameters.

--- a/firmware/IncrementWait/CavaIncrementDevice.v
+++ b/firmware/IncrementWait/CavaIncrementDevice.v
@@ -34,47 +34,96 @@ Import ListNotations.
 Section WithParameters.
   Instance var : tvar := denote_type.
 
+  Existing Instance Incr.inner_specification.
+  Existing Instance Incr.inner_correctness.
+  Existing Instance Incr.inner_invariant.
+
+  Existing Instance TLUL.tl_specification.
+  Existing Instance TLUL.tlul_invariant.
+  Existing Instance TLUL.tlul_adapter_reg_correctness.
+
+  Existing Instance incr_specification.
+  Existing Instance incr_invariant.
+  Existing Instance incr_correctness.
+
   Context {word: Interface.word 32} {word_ok: word.ok word}
           {Mem: map.map word byte} {Registers: map.map Z word}.
 
   Global Instance counter_device: device := {|
     device.state := denote_type (state_of incr);
-    device.is_ready_state s := exists r_regs r_tlul r_inner,
-        incr_invariant s (RSIdle, r_regs, r_tlul, r_inner);
-    device.run1 s i := Semantics.step incr s (i, tt);
+    device.is_ready_state s := exists r_prev_state r_regs r_inner,
+        incr_invariant s (RSIdle, r_prev_state, r_regs, TLUL.Idle, r_inner);
+    device.last_d2h '((_, (_, (_, d2h))), _) := d2h;
+    device.tl_inflight_ops '((_, (_, (_, d2h))), _) :=
+      if d_valid d2h then [d_source d2h] else [];
+    device.run1 s i := fst (Semantics.step incr s (i, tt));
     device.addr_range_start := INCR_BASE_ADDR;
     device.addr_range_pastend := INCR_END_ADDR;
-    device.maxRespDelay '((istate, (val, tl_d2h)), tlul_state) h2d :=
-      (* if the value register was requested, and we're in state Busy1, it will take one
-         more cycle to respond, else we will respond immediately *)
-      if ((a_address h2d mod 8 =? 0(*register address=VALUE*))%N && (istate =? 1 (*Busy1*))%N)%bool
-      then 1%nat else 0%nat;
+    device.maxRespDelay '((_, (_, (_, d2h))), _) :=
+      if a_ready d2h then 2
+      else if d_valid d2h then 1
+           else 0;
+    (* The last [else] is not reachable, because [d_valid] is always the
+       negation of [a_ready]. *)
   |}.
 
   (* conservative upper bound matching the instance given in IncrementWaitToRiscv *)
   Global Instance circuit_spec : circuit_behavior :=
   {| ncycles_processing := 15%nat |}.
 
-  Inductive counter_related_spec: IncrementWaitSemantics.state -> repr -> Prop :=
-  | IDLE_related: forall r_regs r_tl r_inner,
-      counter_related_spec IDLE (RSIdle, r_regs, r_tl, r_inner)
-  | BUSY_related: forall r_regs r_tl r_inner val ncycles,
+
+  Inductive counter_related_base: IncrementWaitSemantics.state -> Incr.repr_state -> Incr.inner_state -> Prop :=
+  | IDLE_related: forall r_innr,
+      counter_related_base IDLE RSIdle r_innr
+  | BUSY1_related: forall val ncycles,
+      (1 < ncycles)%nat ->
+      counter_related_base (BUSY val ncycles) (RSBusy (word_to_N val))
+                           (IISBusy (word_to_N val) 1)
+  | BUSY2_related: forall val ncycles,
       (0 < ncycles)%nat ->
-      counter_related_spec (BUSY val ncycles)
-                           (RSBusy (word_to_N val), r_regs, r_tl, r_inner)
+      counter_related_base (BUSY val ncycles) (RSBusy (word_to_N val))
+                           (IISBusy (word_to_N val) 2)
   (* the hardware is already done, but the software hasn't polled it yet to find out,
      so we have to relate a software-BUSY to a hardware-done: *)
-  | BUSY_done_related: forall r_regs r_tl r_inner val ncycles,
-      counter_related_spec (BUSY val ncycles)
-                           (RSDone (word_to_N (word.add (word.of_Z 1) val)), r_regs, r_tl, r_inner)
-  | DONE_related: forall r_regs r_tl r_inner val,
-      nth 0 r_regs 0%N = (word_to_N val)
-      -> counter_related_spec (DONE val)
-                             (RSDone (word_to_N val), r_regs, r_tl, r_inner).
+  | BUSY_done_related: forall val ncycles r_innr,
+      counter_related_base (BUSY val ncycles) (RSDone (word_to_N (word.add (word.of_Z 1) val))) r_innr
+  | DONE_related: forall val r_innr,
+      counter_related_base (DONE val) (RSDone (word_to_N val)) r_innr.
 
-  Definition counter_related (sH : IncrementWaitSemantics.state)
-             (sL : denote_type (state_of incr)) : Prop :=
-    exists repr, counter_related_spec sH repr /\ incr_invariant sL repr.
+  Inductive counter_related_spec: IncrementWaitSemantics.state -> repr ->
+                                  list tl_h2d -> Prop :=
+  | No_inflight: forall sH r_state r_prev_state r_regs r_inner,
+      counter_related_base sH r_state r_inner ->
+      counter_related_spec sH (r_state, r_prev_state, r_regs, TLUL.Idle, r_inner) []
+  | Inflight_read_status: forall sH r_state r_prev_state r_regs r_tl r_tl_regs r_inner h2d,
+      counter_related_base sH r_state r_inner ->
+      r_tl = TLUL.OutstandingAccessAckData (set_a_address 4 h2d) r_tl_regs ->
+      a_valid h2d = true ->
+      a_opcode h2d = Get ->
+      a_address h2d = word_to_N (state_machine.reg_addr STATUS) ->
+      counter_related_spec sH (r_state, r_prev_state, r_regs, r_tl, r_inner) [h2d]
+  | Inflight_read_value: forall r_prev_state r_regs r_tl r_tl_regs r_inner val h2d,
+      r_tl = TLUL.OutstandingAccessAckData (set_a_address 0 h2d) r_tl_regs ->
+      nth 0 r_tl_regs 0%N = word_to_N val ->
+      a_valid h2d = true ->
+      a_opcode h2d = Get ->
+      a_address h2d = word_to_N (state_machine.reg_addr VALUE) ->
+      counter_related_spec (DONE val)
+                           (RSIdle, r_prev_state, r_regs, r_tl, r_inner)
+                           [h2d]
+  | Inflight_write_value: forall r_prev_state r_regs r_tl r_inner val h2d,
+      r_tl = TLUL.OutstandingAccessAck (set_a_address 0 h2d) ->
+      a_valid h2d = true ->
+      a_opcode h2d = PutFullData ->
+      a_address h2d = word_to_N (state_machine.reg_addr VALUE) ->
+      a_data h2d = (word_to_N val) ->
+      counter_related_spec (IDLE)
+                           (RSBusy (word_to_N val), r_prev_state, r_regs, r_tl, r_inner)
+                           [h2d].
+
+  Definition counter_related {invariant : invariant_for incr repr} (sH : IncrementWaitSemantics.state)
+             (sL : denote_type (state_of incr)) (inflight_h2ds : list tl_h2d) : Prop :=
+    exists repr, counter_related_spec sH repr inflight_h2ds /\ invariant sL repr.
 
   (* This should be in bedrock2.ZnWords. It is use by ZnWords, which is used in
      the two following Lemmas. *)
@@ -104,162 +153,81 @@ Section WithParameters.
       eapply pair_equal_spec in H; destruct H as [?H0 ?H1]
     end.
 
-  (* Ltac destruct_tlul_adapter_reg_state := *)
-  (*   match goal with *)
-  (*   | H : N * (N * (N * (bool * (bool * (bool * bool))))) |- _ => *)
-  (*     destruct H as [?reqid [?reqsz [?rspop [?error [?outstanding [?we_o ?re_o]]]]]] *)
-  (*   end. *)
-
   Lemma N_to_word_word_to_N: forall v, N_to_word (word_to_N v) = v.
   Proof. intros. unfold N_to_word, word_to_N. ZnWords. Qed.
 
-  Existing Instance Incr.inner_specification.
-  Existing Instance Incr.inner_correctness.
-  Existing Instance Incr.inner_invariant.
+(* TODO move to coqutil *)
+Ltac contradictory H :=
+  lazymatch type of H with
+  | ?x <> ?x => exfalso; apply (H eq_refl)
+  | False => case H
+  end.
 
-  Existing Instance TLUL.tlul_specification.
-  Existing Instance TLUL.tlul_adapter_reg_correctness.
-  Existing Instance TLUL.tlul_invariant.
+Require Import coqutil.Tactics.autoforward.
 
-  Existing Instance incr_specification.
-  Existing Instance incr_correctness.
+Ltac fwd_step ::=
+  match goal with
+  | H: ?T |- _ => is_destructible_and T; destr_and H
+  | H: exists y, _ |- _ => let yf := fresh y in destruct H as [yf H]
+  | H: ?x = ?x |- _ => clear H
+  | H: True |- _ => clear H
+  | H: ?LHS = ?RHS |- _ =>
+    let h1 := head_of_app LHS in is_constructor h1;
+    let h2 := head_of_app RHS in is_constructor h2;
+    (* if not eq, H is a contradiction, but we don't want to change the number
+       of open goals in this tactic *)
+    constr_eq h1 h2;
+    (* we don't use `inversion H` or `injection H` because they unfold definitions *)
+    inv_rec LHS RHS;
+    clear H
+  | E: ?x = ?RHS |- context[match ?x with _ => _ end] =>
+    let h := head_of_app RHS in is_constructor h; rewrite E in *
+  | H: context[match ?x with _ => _ end], E: ?x = ?RHS |- _ =>
+    let h := head_of_app RHS in is_constructor h; rewrite E in *
+  | H: context[match ?x with _ => _ end] |- _ =>
+    (* note: recursive invocation of fwd_step for contradictory cases *)
+    destr x; try solve [repeat fwd_step; contradictory H]; []
+  | H: _ |- _ => autoforward with typeclass_instances in H
+  | |- _ => progress subst
+  | |- _ => progress fwd_rewrites
+  end.
 
-  Lemma runUntilResp_big_step : forall s h2d repr,
-      precondition incr (h2d, tt) repr
-      -> a_valid h2d = true
-      -> d_ready h2d = true (* TODO: do we need this? *)
-      -> incr_invariant s repr
-      -> exists n inputs s' repr' d2h s'',
-          device.runUntilResp h2d device.maxRespDelay s = (Some d2h, s'')
-          /\ n <= device.maxRespDelay
-          /\ inputs = repeat (h2d, tt) n
-          /\ s' = snd (simulate' incr inputs s)
-          (* /\ (s'', d2h) = Semantics.step incr s' (h2d, tt) *)
-          /\ repr' = fold_left (fun r i => update_repr (c:=incr) i r) inputs repr
-          (* /\ invariant s' repr' *)
-          /\ postcondition incr (h2d, tt) repr' d2h
-          /\ d_valid d2h = true
-          /\ incr_invariant s'' (update_repr (c:=incr) (h2d, tt) repr').
-  Proof.
-    intros ? ? ? Hprec Ea_valid Ed_ready Hinv.
-    unfold device.maxRespDelay, device.runUntilResp, device.state, device.run1, counter_device,
-    state_machine.read_step, increment_wait_state_machine, read_step in *.
-    eapply output_correct_pf in Hinv as Houtput.
-    apply Houtput in Hprec as Hpostc. clear Houtput.
-    cbn in s, h2d. destruct_tl_h2d.
-    destruct repr as (((?r_state, ?r_regs), ?r_tl), ?r_inner).
-    assert (Hprec_temp := Hprec).
-    unfold precondition, incr_specification in Hprec_temp.
-    logical_simplify.
-    unfold precondition, tlul_specification in H.
-    logical_simplify. tlsimpl. subst.
-    unfold postcondition, incr_specification in Hpostc.
-    unfold postcondition, tlul_specification in Hpostc.
-    destruct Hpostc as [[is_read [is_write [address [w_val w_mask]]]] [h2d' [regs' [d2h' [is_read' [is_write' [address' [w_val' [w_mask' Hpostc]]]]]]]]].
-    destruct_tl_h2d. destruct_tl_d2h. tlsimpl.
-    destruct Hpostc as [Hpostc1 [Hpostc2 Hpostc3]].
-    subst.
-    apply pair_equal_spec in Hpostc2.
-    logical_simplify.
-    cbn [outstanding_h2d] in Hpostc3.
-    destruct (outstanding_h2d r_tl) eqn:Eouts.
-    - cbn in Hpostc3. logical_simplify. subst.
-      assert (Hprec':
-                precondition incr
-                             (true,
-                              (a_opcode0,
-                               (a_param0, (a_size0, (a_source0, (a_address, (a_mask0, (a_data0, (a_user0, true)))))))), tt)
-                             (update_repr (c:=incr)
-                                          (true,
-                                           (a_opcode0,
-                                            (a_param0, (a_size0, (a_source0, (a_address, (a_mask0, (a_data0, (a_user0, true)))))))), tt)
-                                          (r_state, regs', r_tl, r_inner))).
-      { simplify_spec incr.
-        cbn [outstanding_h2d]. rewrite Eouts.
-        tlsimpl. ssplit.
-        - simplify_spec (tlul_adapter_reg (reg_count:=2)). tlsimpl. split; [|assumption].
-          match goal with
-          | |- context [length (match ?m with | _=> _ end)] =>
-            destruct m
-          end;
-          match goal with
-          | |- context [replace _ _ (match ?m with | _=> _ end)] =>
-            destruct m
-          end; rewrite ! length_replace; assumption.
-        - simplify_spec Incr.inner. intros. apply I.
-      }
-      destruct H1; [auto|..]; subst.
-      all: exists 1.
-      all: destruct_pair_let;
-        match goal with
-        | |- context [if d_valid ?c then _ else _] =>
-          match type of H2 with
-          | _ = ?r => replace c with r
-          end
-        end.
-      all: tlsimpl;
-        assert (Hinv' := Hprec);
-        eapply incr_invariant_preserved in Hinv;
-        [apply Hinv in Hinv'|reflexivity]; clear Hinv.
-      all: eapply output_correct_pf in Hinv' as Houtput';
-        apply Houtput' in Hprec' as Hpostc'; clear Houtput';
-          assert (Hpostc'' := Hpostc');
-        unfold postcondition, incr_specification in Hpostc';
-        unfold postcondition, tlul_specification in Hpostc';
-        cbn [update_repr outstanding_h2d] in Hpostc';
-        rewrite Eouts in Hpostc'; cbn -[Semantics.step] in Hpostc';
-        destruct Hpostc' as [[is_read [is_write [address [w_val w_mask]]]] [h2d' [regs'' [d2h' [is_read' [is_write' [address'' [w_val'' [w_mask'' Hpostc']]]]]]]]].
-      all: destruct_tl_h2d; destruct_tl_d2h; tlsimpl;
-        destruct Hpostc' as [Hpostc1' [Hpostc2' Hpostc3']];
-        subst;
-        apply pair_equal_spec in Hpostc2';
-        logical_simplify;
-        rewrite Eouts in Hpostc3';
-        tlsimpl.
-      all: cbn in Hpostc3'; logical_simplify; subst.
-      all: do 5 eexists; ssplit; try reflexivity.
-      1,5: destruct_pair_let;
-                match goal with
-        | |- context [if d_valid ?c then _ else _] =>
-          match type of H1 with
-          | _ = ?r => replace c with r
-          end
-        end; tlsimpl; reflexivity.
-      1,4: cbn [repeat fold_left];
-        match goal with
-        | H: postcondition incr _ _ ?c |- _ =>
-          match type of H1 with
-          | _ = ?r => replace c with r in H; apply H
-          end
-        end.
-      1,3: reflexivity.
-      1,2: cbn [repeat fold_left];
-        eapply incr_invariant_preserved; [reflexivity|assumption..].
-    - destruct H1; [auto|..]; subst; cbn in Hpostc3; logical_simplify; subst.
-      all: exists 0.
-      all: do 5 eexists; ssplit; try reflexivity; try lia.
-      1,5: destruct_pair_let;
-        match goal with
-        | |- context [if d_valid ?c then _ else _] =>
-          match type of H2 with
-          | _ = ?r => replace c with r
-          end
-        end; tlsimpl; reflexivity.
-      1,4: cbn [repeat fold_left];
-        eapply output_correct_pf in Hinv as Houtput;
-        apply Houtput in Hprec;
-        match goal with
-        | H: postcondition incr _ _ ?c |- _ =>
-          match type of H2 with
-          | _ = ?r => replace c with r in H; apply H
-          end
-        end.
-      1,3: reflexivity.
-      1,2: cbn [repeat fold_left];
-        eapply incr_invariant_preserved; [reflexivity|assumption..].
-  Qed.
+  Axiom TODO: False.
 
-  (* Set Printing All. *)
+  Ltac use_spec :=
+    match goal with
+    | Hrun: device.run1 ?sL ?input = ?sL',
+            Hinv: incr_invariant ?sL ?repr
+      |- _ =>
+      assert (Hprec: precondition incr (input, tt) repr);
+      [|
+       (* pose proof (output_correct_pf (c:=incr) (input, tt) sL repr Hinv Hprec) as Hpostc. *)
+       remember (update_repr (c:=incr) (input, tt) repr) as repr' eqn:Erepr';
+       pose proof (invariant_preserved_pf (c:=incr) (input, tt) sL repr repr' Erepr' Hinv Hprec) as Hinv';
+       unfold device.run1, counter_device in Hrun;
+       match type of Hrun with
+       | fst ?step = _ =>
+         remember step as res eqn:Hstep;
+         destruct res as (?sL'' & ?d2h);
+         cbn in Hrun; subst sL''; clear Hstep
+       end;
+       cbn [fst] in Hinv']
+    end.
+
+  Ltac inversion_rel_spec :=
+    match goal with
+    | H: counter_related_spec _ _ _ |- _ => inversion H; subst
+    end.
+  Ltac inversion_rel_base :=
+    match goal with
+    | H: counter_related_base _ _ _ |- _ => inversion H; subst
+    end.
+
+  (* Lemma output_last_d2h : forall s h2d s' d2h, *)
+  (*     (s', d2h) = Semantics.step incr s (h2d, tt) -> *)
+  (*     device.last_d2h s' = d2h. *)
+  (* Proof. *)
+
   Global Instance cava_counter_satisfies_state_machine:
     device_implements_state_machine counter_device increment_wait_state_machine.
   Proof.
@@ -267,194 +235,323 @@ Section WithParameters.
     - (* mmioAddrs_match: *)
       reflexivity.
     - (* initial_state_is_ready_state: *)
-      intros ? ? Hinit Hrel.
+      intros ? ? ? Hrel.
       cbn in *. subst. destruct Hrel as [?repr [?Hrel ?Hinv]].
-      inversion Hrel. subst.
-      do 3 eexists. eapply Hinv.
+      inversion_rel_spec. inversion_rel_base.
+      repeat eexists. eapply Hinv.
     - (* initial_states_are_related: *)
-      intros ? ? Hinit Hready.
-      cbn in *. destruct Hready as (?r_regs & ?r_tl & ?r_inner & ?Hinv). subst.
+      intros ? ? ? Hready.
+      cbn in *. destruct Hready as (?r_prev_state & ?r_regs & ?r_inner & ?Hinv). subst.
       unfold counter_related. eexists. split; [|apply Hinv].
-      apply IDLE_related.
+      apply No_inflight, IDLE_related.
     - (* initial_state_exists: *)
       intros ? Hready.
-      cbn in *. destruct Hready as (?r_regs & ?r_tl & ?r_inner & ?Hinv).
+      cbn in *. destruct Hready as (?r_prev_state & ?r_regs & ?r_inner & ?Hinv).
       eexists. split; [reflexivity|].
       unfold counter_related. eexists. split; [|apply Hinv].
-      apply IDLE_related.
+      apply No_inflight, IDLE_related.
     - (* nonMMIO_device_step_preserves_state_machine_state: *)
-      intros ? ? ? ? ? Ha_valid Hrel.
-      (* cbn in sL1, sL2. *)
-      (* destruct sL2 as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner)). *)
-      (* destruct_tl_h2d. destruct_tl_d2h. tlsimpl. subst. *)
-      unfold device.run1. unfold counter_device.
-      intros Hstep.
-      destruct Hrel as [?repr [?Hrel ?Hinv]].
-      assert (Hprec: precondition incr (h2d, tt) repr).
+      intros ? ? ? ? Ha_valid [repr [Hrel Hinv]] **.
+      use_spec.
       { destruct_tl_h2d. destruct_tl_d2h. tlsimpl.
         cbn in sL1; destruct sL1 as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner)).
-        destruct repr as (((?r_state, ?r_regs), ?r_tl), ?r_inner).
+        destruct repr as ((((?r_state, ?r_prev_state), ?r_regs), ?r_tl), ?r_inner).
         simplify_invariant incr. logical_simplify.
-        subst. cbn. ssplit.
-        - auto.
-        - intros. discriminate.
-        - intros. auto.
+        subst. cbn. ssplit; intros; [auto|discriminate|auto].
       }
-      eapply incr_invariant_preserved in Hinv as Hinv'; [|reflexivity].
-      unfold counter_related. exists (update_repr (c:=incr) (h2d, tt) repr).
-      rewrite surjective_pairing with (A:=counter_device) (B:=tl_d2h)
-                                      (p:=Semantics.step incr sL1 (h2d, tt)) in Hstep.
-      apply pair_equal_spec in Hstep. destruct Hstep as [Hstep1 Hstep2]. subst.
-      split; [| apply Hinv'; apply Hprec].
-      inversion Hrel; subst;
+      exists repr'; split; [|auto].
+      inversion_rel_spec; inversion_rel_base;
         destruct_tl_h2d; destruct_tl_d2h; tlsimpl; subst;
           cbn in sL1; destruct sL1 as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner));
-            simplify_invariant incr; logical_simplify; subst;
-              cbn -[replace].
-      all: try (destruct x as [|[|[|]]]);
-        destruct (outstanding_h2d r_tl), d_ready;
-        try destruct (TLUL.a_opcode t =? Get)%N, (TLUL.a_opcode t =? PutFullData)%N;
-        try (rewrite incrN_word_to_bv);
-        boolsimpl; constructor; try assumption.
-      all: destruct H6; subst; destruct r_regs; cbn in H |- *; assumption.
-    - (* state_machine_read_to_device_read: *)
-      (* simpler because device.maxRespDelay=1 *)
-      intros ? ? ? ? [v [sH'' Hex_read]] [repr Hrel].
-      cbn in Hex_read. logical_simplify. rewrite  H1.
-      unfold counter_related.
-      match goal with
-      | |- context [ device.runUntilResp ?x _ _ ] =>
-        remember x as h2d eqn:Eh2d; replace x with h2d
-      end.
-      assert (Hprec: precondition incr (h2d, tt) repr).
-      { destruct_tl_h2d. tlsimpl.
-        cbn in sL; destruct sL as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner)).
-        destruct repr as (((?r_state, ?r_regs), ?r_tl), ?r_inner).
-        simplify_invariant incr. logical_simplify.
-        subst. cbn. ssplit; intros; auto.
-      }
-      pose (r_ := r). destruct r.
-      + (* r=VALUE *)
-        pose (sH_ := sH); destruct sH; cbn in H2; try (exfalso; assumption); logical_simplify; subst.
-        inversion H; subst.
-        eapply runUntilResp_big_step with (s:=sL) in Hprec
-          as [n [inputs [sL' [repr' [d2h [sL'' [HrunU [HmaxRespDelay [Einputs [EsL' [Erepr' [Hpostc' [Ed_valid Hinv'']]]]]]]]]]]]]; subst; auto.
-        exists d2h, sL'', IDLE.
-        ssplit.
-        3: cbn; ssplit; try reflexivity; [].
-        * assumption.
-        * eexists.
-          split; [|apply Hinv''].
+            simplify_invariant incr; logical_simplify; subst; cbn -[replace];
+              apply No_inflight; try (constructor; lia); [].
+      replace ((word_to_N val + 1) mod 4294967296)%N with
+          (word_to_N (word.add (word.of_Z 1) val)) by
+          (unfold word_to_N; ZnWords);
+        apply BUSY_done_related.
+
+    - (* [state_machine_read_to_device_send_read_or_later] *)
+      intros ? ? ? ? ? ? [v [sH'' Hex_read]] [repr [Hrel Hinv]] **.
+      cbn in Hex_read. logical_simplify.
+      rewrite H5. clear H5.
+      use_spec.
+      1: simplify_spec incr; simplify_spec (tlul_adapter_reg (reg_count:=2)); simplify_spec Incr.inner;
+        simplify_invariant incr;
+        cbn in sL; destruct sL as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner));
+          destruct repr as ((((?r_state, ?r_prev_state), ?r_regs), ?r_tl), ?r_inner);
+          destruct_tl_h2d; tlsimpl; logical_simplify; subst;
+            ssplit; intros; auto.
+
+      destruct_one_match; [destruct_one_match|].
+      (* case 1: device ready, valid response
+           In our TL implementation [a_ready = negb d_valid], hence this case
+           is not possible.
+           case 3: device not ready
+           If the inflight queue is empty, the device must be ready, hence
+           this case is not possible. *)
+      1,3: exfalso;
+        unfold device.last_d2h, counter_device in *;
+        cbn in sL; destruct sL as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner));
+          destruct repr as ((((?r_state, ?r_prev_state), ?r_regs), ?r_tl), ?r_inner);
+          simplify_invariant incr; subst; logical_simplify; destruct_tl_d2h; tlsimpl; subst;
+          inversion_rel_spec; logical_simplify; discriminate.
+      (* device ready, no valid response: *)
+      ssplit.
+      1: eexists; split; [|eassumption]; [].
+      all:
+        unfold device.tl_inflight_ops, device.last_d2h, device.maxRespDelay,
+        counter_device, counter_related in *;
+        cbn in sL; destruct sL as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner));
+          cbn in sL'; destruct sL' as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner));
+            destruct repr as ((((?r_state, ?r_prev_state), ?r_regs), ?r_tl), ?r_inner);
+            destruct_tl_d2h; destruct_tl_h2d;
+              simplify_spec incr; simplify_spec (tlul_adapter_reg (reg_count:=2));
+                simplify_invariant incr;
+                logical_simplify; tlsimpl; subst;
+                  cbn in Hinv'; logical_simplify; subst.
+      + destruct r.
+        * (* [r:=VALUE] *)
+          inversion_rel_spec; inversion_rel_base; destruct H6; subst.
+          cbn; replace (N.land (word_to_N (word.of_Z 16384)) 4) with 0%N
+            by (rewrite Z_word_N by lia; reflexivity);
+          cbn; eapply Inflight_read_value; [eauto| |reflexivity..].
+          logical_simplify. assumption.
+        * (* [r:=STATUS] *)
+          inversion_rel_spec; inversion_rel_base; subst; logical_simplify; subst; cbn.
+            eapply Inflight_read_status; try (constructor; lia).
+          all: replace (N.land (word_to_N (word.of_Z 16388)) 4) with 4%N
+            by (rewrite Z_word_N by lia; reflexivity); eauto.
+          all: cbn; replace ((word_to_N val + 1) mod 4294967296)%N with
+                        (word_to_N (word.add (word.of_Z 1) val)) by
+              (unfold word_to_N; ZnWords); constructor.
+
+      + inversion_rel_spec; inversion_rel_base; subst; logical_simplify; subst; lia.
+
+    - (* [state_machine_read_to_device_ack_read_or_later] *)
+      intros ? ? ? ? ? ? [v [sH'' Hex_read]] [repr [Hrel Hinv]] **.
+      (* assert (Hex_rel: exists sL'' h2d', device.run1 sL'' (set_d_ready true h2d') = sL /\ *)
+      (*                               counter_related sH sL'' []). *)
+      (* { admit. } *)
+      (* logical_simplify. destruct H0 as [repr'' [Hrel'' Hinv'']]. *)
+      (* use_spec. 1: admit. *)
+      (* rename Hprec into Hprec''. rename repr' into repr'''. rename Erepr' into Erepr''. rename Hinv' into Hinv'''. *)
+      cbn in Hex_read. logical_simplify.
+      rewrite H2. clear H2. rename H3 into Hex_read.
+      use_spec.
+      1: simplify_spec incr; simplify_spec (tlul_adapter_reg (reg_count:=2)); simplify_spec Incr.inner;
+        simplify_invariant incr;
+        cbn in sL; destruct sL as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner));
+          destruct repr as (((?r_state, ?r_regs), ?r_tl), ?r_inner);
+          destruct r_state;
+          destruct_tl_h2d; tlsimpl; logical_simplify; subst;
+            ssplit; intros; auto.
+
+      destruct_one_match.
+      (* case 2: no valid response
+         If the inflight queue is not empty, the device must be sending a
+         response, hence this case is not possible. *)
+      2: unfold device.last_d2h, counter_device in *;
+        cbn in sL; destruct sL as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner));
+          destruct repr as (((?r_state, ?r_regs), ?r_tl), ?r_inner);
+          simplify_invariant incr; subst; logical_simplify; destruct_tl_d2h; tlsimpl; subst;
+            inversion_rel_spec; try inversion_rel_base; logical_simplify; subst;
+              try destruct r_tl; logical_simplify; subst;
+                discriminate.
+
+      (* case 1: valid response *)
+      destruct r.
+      + (* [r:=VALUE] *)
+        inversion_rel_spec;
+          try (exfalso; destruct_tl_h2d; tlsimpl; subst; unfold word_to_N in *; cbn in *; ZnWords).
+
+        destruct Hex_read; subst.
+        logical_simplify; subst.
+        exists IDLE. ssplit.
+        * eexists. split; [|eassumption].
+          cbn.
+          cbn in sL; destruct sL as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner));
+            simplify_invariant incr;
+            logical_simplify; tlsimpl; subst.
+          apply No_inflight, IDLE_related.
+        * cbn. ssplit; try reflexivity.
+          clear Hinv'.
+          cbn in sL; destruct sL as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner));
           simplify_invariant incr.
-          simplify_invariant Incr.inner.
-          simplify_invariant (tlul_adapter_reg (reg_count:=2)).
-          cbn in sL''; destruct sL'' as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner)).
-          clear HrunU.
-          pose (n_:=n). destruct n as [|[|n]].
-          3: unfold device.maxRespDelay, counter_device in HmaxRespDelay; exfalso; lia.
-          all: cbn [repeat fold_left] in *.
-          -- destruct Hpostc' as [req' [h2d' [regs' [d2h' [io_re' [io_we' [io_address' [io_data' [io_mask' Hpostc']]]]]]]]].
-             logical_simplify.
-             cbn in H5.
-             destruct (outstanding_h2d r_tl) eqn:Houts.
-             ++ logical_simplify. rewrite Ed_valid in * |-. discriminate.
-             ++ cbn in H5. logical_simplify.
-                destruct_tl_d2h. tlsimpl. subst.
-                simplify_invariant incr.
-                cbn in sL; destruct sL as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner)).
-                cbn in Hinv'' |- *.
-                rewrite Houts in Hinv'' |- *. cbn in Hinv''. logical_simplify.
-                cbn in *.
-                logical_simplify. subst.
-                rewrite Z_word_N in * by lia. cbn in *. logical_simplify. subst.
-                apply IDLE_related.
-          -- cbn in Hpostc'.
-             destruct (outstanding_h2d r_tl) eqn:Houts;
-             destruct Hpostc' as [req' [h2d' [regs' [d2h' [io_re' [io_we' [io_address' [io_data' [io_mask' Hpostc']]]]]]]]];
-             logical_simplify;
-             cbn in H5; rewrite Houts in H5; cbn in H5; logical_simplify; subst.
-             ++ destruct_tl_d2h. tlsimpl. subst.
-                simplify_invariant incr.
-                cbn in sL; destruct sL as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner)).
-                cbn in Hinv'' |- *.
-                rewrite Houts in Hinv'' |- *. cbn in Hinv'' |- *. logical_simplify.
-                rewrite Houts. cbn.
-                rewrite Z_word_N in * by lia. cbn in *.
-                destruct H8; subst; apply IDLE_related.
-             ++ rewrite Ed_valid in * |-. discriminate.
-        * pose (n_:=n). destruct n as [|[|n]].
-          -- cbn [repeat fold_left] in *.
-             destruct Hpostc' as [req' [h2d' [regs' [d2h' [io_re' [io_we' [io_address' [io_data' [io_mask' Hpostc']]]]]]]]].
-             logical_simplify.
-             cbn in H5.
-             destruct (outstanding_h2d r_tl) eqn:Houts.
-             ++ logical_simplify. rewrite Ed_valid in * |-. discriminate.
-             ++ cbn in H5. logical_simplify.
-                destruct_tl_d2h. tlsimpl. subst.
-                simplify_invariant incr.
-                cbn in sL; destruct sL as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner)).
-                cbn in sL''; destruct sL'' as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner)).
-                cbn in Hinv''.
-                rewrite Houts in Hinv''. cbn in Hinv''. logical_simplify.
-                cbn in *.
-                logical_simplify. subst.
-                rewrite Z_word_N in * by lia. cbn in *. logical_simplify. subst.
-                rewrite H3. apply N_to_word_word_to_N.
-          -- cbn [repeat fold_left] in *.
-             cbn in Hpostc'.
-             destruct (outstanding_h2d r_tl) eqn:Houts;
-             destruct Hpostc' as [req' [h2d' [regs' [d2h' [io_re' [io_we' [io_address' [io_data' [io_mask' Hpostc']]]]]]]]];
-             logical_simplify;
-             cbn in H5; rewrite Houts in H5; cbn in H5; logical_simplify; subst.
-             ++ destruct_tl_d2h. tlsimpl. subst.
-                simplify_invariant incr.
-                cbn in sL; destruct sL as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner)).
-                cbn in sL''; destruct sL'' as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner)).
-                cbn in Hinv''.
-                rewrite Houts in Hinv''. cbn in Hinv''. logical_simplify.
-                rewrite Z_word_N in * by lia. cbn -[replace] in *.
-                destruct H8; subst; destruct r_regs; cbn in H3 |- *;
-                  rewrite H3; apply N_to_word_word_to_N.
-             ++ rewrite Ed_valid in * |-. discriminate.
-          -- unfold device.maxRespDelay, counter_device in HmaxRespDelay. exfalso. lia.
-      + (* r=STATUS *)
-        eapply runUntilResp_big_step in Hprec as [n [inputs [sL' [repr' [d2h [sL'' [HrunU [HmaxRespDelay [Einputs [EsL' [Erepr' [Hpostc' [Ed_valid Hinv'']]]]]]]]]]]]]; subst; auto; [|eassumption].
-        inversion H; subst.
-        * do 3 eexists; ssplit.
-          -- rewrite HrunU; reflexivity.
-          -- eexists; split; [|eassumption];
-               destruct n as [|[|n]];
-               [| |unfold device.maxRespDelay, counter_device in HmaxRespDelay; exfalso; lia];
-               cbn [repeat fold_left] in *;
-               simplify_invariant incr;
-               cbn in sL; destruct sL as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner));
-                 logical_simplify; subst;
-                   cbn; destruct (outstanding_h2d r_tl) eqn:Eouts;
-                     try (cbn; rewrite Eouts; cbn);
-                     apply IDLE_related.
-          -- cbn. ssplit; try reflexivity.
-             destruct n as [|[|n]];
-               [| |unfold device.maxRespDelay, counter_device in HmaxRespDelay; exfalso; lia];
-               cbn [repeat fold_left] in *; simplify_spec incr;
-                 simplify_spec (tlul_adapter_reg (reg_count:=2)).
-             ++ destruct Hpostc' as [req' [h2d' [regs' [d2h' [io_re' [io_we' [io_address' [io_data' [io_mask' Hpostc']]]]]]]]]; logical_simplify; cbn in H5;
-                  destruct (outstanding_h2d r_tl) eqn:Eouts;
-                  [logical_simplify; rewrite Ed_valid in *; discriminate|];
-                  cbn in H5; logical_simplify; rewrite H9.
-                unfold status_value, STATUS_IDLE, N_to_word, word_to_N.
-                simplify_invariant incr.
-                cbn in sL; destruct sL as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner)).
-                logical_simplify.
-                replace (N.to_nat ((N.land (Z.to_N (word.unsigned (word.of_Z 16388))) 4 / 4) mod 1073741824)) with 1.
-                ** ZnWords.
-                ** ZnWords_pre. rewrite Zmod_small; [|lia].
-                   rewrite N.mod_small; cbn; lia.
-             ++ admit.
-        * admit.
-        * admit.
-        * admit.
-    - (* state_machine_write_to_device_write: *)
-      admit.
+          logical_simplify; subst.
+          destruct_tl_h2d; tlsimpl; subst.
+          rewrite H19. cbn. rewrite H3. apply N_to_word_word_to_N.
+      + (* [r:=STATUS] *)
+        inversion_rel_spec;
+          try (exfalso; destruct_tl_h2d; tlsimpl; subst; unfold word_to_N in *; cbn in *; ZnWords).
+
+        inversion_rel_base;
+          cbn in sL |- *; destruct sL as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner));
+            simplify_invariant incr;
+            logical_simplify; subst; logical_simplify; subst;
+              match goal with
+              | H: d_data _ = _ |- _ =>
+                rewrite H
+              end;
+              cbn; destruct_tl_h2d; tlsimpl; subst; cbn;
+              change (Pos.to_nat 1) with 1.
+                (* match goal with *)
+                (* | H: nth 1 r_tl_regs 0%N = _ |- _ => rewrite H *)
+                (* end; *)
+                (* unfold N_to_word, status_value. *)
+        * eexists; ssplit; try reflexivity.
+          -- eexists.
+             ssplit; [|eassumption].
+             apply No_inflight. constructor.
+          -- assert (Hprev: r_prev_state = RSIdle) by admit.
+             subst.
+             match goal with
+             | H: nth 1 r_tl_regs 0%N = _ |- _ => rewrite H
+             end; unfold N_to_word, status_value.
+             ZnWords.
+        * destruct ncycles as [|ncycles]; [lia|].
+          eexists; ssplit; try reflexivity.
+          -- eexists. ssplit; [|eassumption].
+             apply No_inflight, BUSY2_related. apply lt_S_n. eauto.
+          -- right. eexists. ssplit; [reflexivity| |reflexivity].
+             assert (Hprev: exists d, r_prev_state = RSBusy d) by admit.
+             logical_simplify; subst.
+             match goal with
+             | H: nth 1 r_tl_regs 0%N = _ |- _ => rewrite H
+             end; unfold N_to_word, status_value.
+             ZnWords.
+        * destruct ncycles as [|ncycles]; [lia|].
+          eexists. ssplit; try reflexivity.
+          -- eexists. ssplit; [|eassumption].
+             cbn; rewrite incrN_word_to_bv.
+             apply No_inflight, BUSY_done_related.
+          -- right. eexists. ssplit; [reflexivity| |reflexivity].
+             assert (Hprev: exists d, r_prev_state = RSBusy d) by admit.
+             logical_simplify; subst.
+             match goal with
+             | H: nth 1 r_tl_regs 0%N = _ |- _ => rewrite H
+             end; unfold N_to_word, status_value.
+             ZnWords.
+        * eexists; ssplit; try reflexivity.
+          -- eexists. ssplit; [|eassumption].
+             apply No_inflight, DONE_related.
+          -- left. ssplit; [|reflexivity].
+             assert (Hprev: exists d, r_prev_state = RSDone d) by admit.
+             logical_simplify; subst; logical_simplify;
+             match goal with
+             | H: nth 1 r_tl_regs 0%N = _ |- _ => rewrite H
+             end; unfold N_to_word, status_value.
+             ZnWords.
+        * eexists; ssplit; try reflexivity.
+          -- eexists. ssplit; [|eassumption].
+             apply No_inflight, DONE_related.
+          -- assert (Hprev: exists d, r_prev_state = RSDone d) by admit.
+             logical_simplify; subst; logical_simplify.
+             match goal with
+             | H: nth 1 r_tl_regs 0%N = _ |- _ => rewrite H
+             end; unfold N_to_word, status_value.
+             ZnWords.
+
+    - (* [state_machine_write_to_device_send_write_or_later] *)
+      intros ? ? ? ? ? ? ? [sH'' [Hpow2 Hex_write]] [repr [Hrel Hinv]] **.
+      rewrite Hpow2. clear Hpow2.
+      use_spec.
+      1: simplify_spec incr; simplify_spec (tlul_adapter_reg (reg_count:=2)); simplify_spec Incr.inner;
+        simplify_invariant incr;
+        cbn in sL; destruct sL as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner));
+          destruct repr as ((((?r_state, ?r_prev_state), ?r_regs), ?r_tl), ?r_inner);
+          destruct_tl_h2d; tlsimpl; logical_simplify; subst;
+            ssplit; intros; auto.
+
+      destruct_one_match; [destruct_one_match|].
+        (* case 1: device ready, valid response
+           In our TL implementation [a_ready = negb d_valid], hence this case
+           is not possible.
+           case 3: device not ready
+           If the inflight queue is empty, the device must be ready, hence
+           this case is not possible. *)
+      1,3: exfalso;
+        unfold device.last_d2h, counter_device in *;
+        cbn in sL; destruct sL as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner));
+        destruct repr as ((((?r_state, ?r_prev_state), ?r_regs), ?r_tl), ?r_inner);
+          simplify_invariant incr; subst; logical_simplify; destruct_tl_d2h; tlsimpl; subst;
+            inversion_rel_spec; logical_simplify; discriminate.
+      (* device ready, no valid response: *)
+      ssplit.
+      1: eexists; split; [|eassumption]; [].
+      all:
+        unfold device.tl_inflight_ops, device.last_d2h, device.maxRespDelay,
+        counter_device, counter_related in *;
+        cbn in sL; destruct sL as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner));
+          cbn in sL'; destruct sL' as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner));
+            destruct repr as ((((?r_state, ?r_prev_state), ?r_regs), ?r_tl), ?r_inner);
+            destruct_tl_d2h; destruct_tl_h2d;
+              simplify_spec incr; simplify_spec (tlul_adapter_reg (reg_count:=2));
+                simplify_invariant incr;
+                logical_simplify; tlsimpl; subst;
+                  cbn in Hinv'; logical_simplify; subst.
+      + destruct r.
+        * (* [r:=VALUE] *)
+          inversion_rel_spec; inversion_rel_base; logical_simplify; subst; try contradiction.
+          cbn. apply Inflight_write_value; eauto; [].
+          rewrite Z_word_N by lia. change (Z.to_N 16384) with 16384%N. reflexivity.
+        * (* [r:=STATUS] *)
+          inversion_rel_spec; inversion_rel_base;
+          destruct Hex_write.
+      + inversion_rel_spec; inversion_rel_base; subst; logical_simplify; subst; lia.
+
+    - (* [state_machine_write_to_device_ack_write_or_later] *)
+      intros ? ? ? ? ? ? ? [sH'' [Hpow2 Hex_write]] [repr [Hrel Hinv]] **.
+      rewrite Hpow2 in *. clear Hpow2.
+      use_spec.
+      1: simplify_spec incr; simplify_spec (tlul_adapter_reg (reg_count:=2)); simplify_spec Incr.inner;
+        simplify_invariant incr;
+        cbn in sL; destruct sL as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner));
+          destruct repr as ((((?r_state, ?r_prev_state), ?r_regs), ?r_tl), ?r_inner);
+          destruct_tl_h2d; tlsimpl; logical_simplify; subst;
+            ssplit; intros; auto.
+
+      destruct_one_match.
+      (* case 2: no valid response
+         If the inflight queue is not empty, the device must be sending a
+         response, hence this case is not possible. *)
+      2: unfold device.last_d2h, counter_device in *;
+        cbn in sL; destruct sL as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner));
+          destruct repr as ((((?r_state, ?r_prev_state), ?r_regs), ?r_tl), ?r_inner);
+          simplify_invariant incr; subst; logical_simplify; destruct_tl_d2h; tlsimpl; subst;
+            inversion_rel_spec; try inversion_rel_base; logical_simplify; subst;
+              try destruct r_tl; logical_simplify; subst;
+                discriminate.
+
+      (* case 1: valid response *)
+      destruct r.
+      + (* [r:=VALUE] *)
+        inversion_rel_spec;
+          try (exfalso; destruct_tl_h2d; tlsimpl; subst; unfold word_to_N in *; cbn in *; ZnWords).
+
+        destruct Hex_write; subst.
+        logical_simplify; subst.
+        eexists. ssplit; [|cbn; split; reflexivity].
+        eexists. split; [|eassumption].
+        cbn.
+        cbn in sL; destruct sL as ((?busy, (?done, (?regs, ?d2h))), (?s_tl, ?s_inner));
+            simplify_invariant incr;
+            logical_simplify; tlsimpl; subst.
+        apply No_inflight.
+        simplify_invariant Incr.inner; destruct s_inner; logical_simplify.
+        destruct x as [|[|[|]]]; [exfalso; lia|..| exfalso; lia];
+          destruct_tl_h2d; tlsimpl; subst;
+            match goal with
+            | H: word_to_N v = word_to_N val |- _ =>
+              rewrite <- H
+            end.
+        * constructor; lia.
+        * replace ((word_to_N v + 1) mod 4294967296)%N with
+                        (word_to_N (word.add (word.of_Z 1) v)) by
+              (unfold word_to_N; ZnWords).
+          constructor.
+      + (* [r:=STATUS] *)
+        inversion_rel_spec;
+          try (exfalso; destruct_tl_h2d; tlsimpl; subst; unfold word_to_N in *; cbn in *; ZnWords).
     - (* read_step_unique: *)
       intros. simpl in *. unfold read_step in *. simp.
       destruct v; destruct r; try contradiction; simp; try reflexivity.

--- a/firmware/IncrementWait/Incr.v
+++ b/firmware/IncrementWait/Incr.v
@@ -1,0 +1,598 @@
+Require Import Coq.Lists.List.
+Require Import Coq.micromega.Lia.
+Require Import Coq.ZArith.ZArith.
+
+Require Import Cava.Expr.
+Require Import Cava.ExprProperties.
+Require Import Cava.Invariant.
+Require Import Cava.Primitives.
+Require Import Cava.Semantics.
+Require Import Cava.TLUL.
+Require Import Cava.Types.
+Require Import Cava.Util.BitArithmetic.
+Require Import Cava.Util.List.
+Require Import Cava.Util.Tactics.
+
+Require Import coqutil.Tactics.Simp.
+Require Import coqutil.Tactics.Tactics.
+
+Import ListNotations.
+
+Section Var.
+  Import Expr.
+  Import ExprNotations.
+  Import PrimitiveNotations.
+
+  Local Open Scope N.
+
+  Context {var : tvar}.
+
+  Definition incr_state := BitVec 2.
+  Definition Idle       := Constant incr_state 0.
+  Definition Busy1      := Constant incr_state 1.
+  Definition Busy2      := Constant incr_state 2.
+  Definition Done       := Constant incr_state 3.
+
+  Definition inner
+    : Circuit _ [Bit; BitVec 32] (Bit ** BitVec 32)
+    := {{
+      fun valid data =>
+        let/delay '(istate; value) :=
+           let istate' :=
+               if istate == `Busy1` then `Busy2`
+               else if istate == `Busy2` then `Done`
+                    else if istate == `Done` then `Idle`
+                         else (* istate == `Idle` *)
+                           if valid then `Busy1`
+                           else `Idle` in
+
+           let value' :=
+               if istate == `Busy2` then value + `K 1`
+               else if istate == `Idle` then data
+                    else value in
+
+           (istate', value')
+             initially default
+           : denote_type (incr_state ** BitVec 32)
+        in
+        (istate == `Done`, value)
+       }}.
+
+  Definition incr
+    : Circuit _ [tl_h2d_t] tl_d2h_t
+    := {{
+      fun tl_h2d =>
+        (* Destruct and reassemble tl_h2d with a_address that matches the
+           tlul_adapter_reg interface. *)
+        let '(a_valid
+              , a_opcode
+              , a_param
+              , a_size
+              , a_source
+              , a_address
+              , a_mask
+              , a_data
+              , a_user
+              ; d_ready) := tl_h2d in
+        (* Bit #2 of the address determines which register is being accessed *)
+        (*    (STATUS or VALUE). Zero out the other bits. *)
+        let a_address := a_address & (`K 1` << 2) in
+        let tl_h2d := (a_valid
+                       , a_opcode
+                       , a_param
+                       , a_size
+                       , a_source
+                       , a_address
+                       , a_mask
+                       , a_data
+                       , a_user
+                       , d_ready) in
+
+        let/delay '(busy, done, registers; tl_d2h) :=
+           let '(tl_d2h'; req) := `tlul_adapter_reg` tl_h2d registers in
+           let '(is_read, is_write, address, write_data; _write_mask) := req in
+
+           let '(inner_res_valid; inner_res) := `inner` (!busy && !done && is_write) write_data in
+
+           let busy' :=
+               if busy then !inner_res_valid
+               else !done && is_write in
+
+           let done' :=
+               if busy then inner_res_valid
+               else if done then !(is_read && address == `K 0`)
+                    else done in
+
+           let registers' :=
+               if inner_res_valid then `replace` registers `K (sz:=1) 0` inner_res
+               else registers in
+
+           let registers' :=
+               if busy' then `replace` registers' `K (sz:=1) 1` `K 2`
+               else if done' then `replace` registers' `K (sz:=1) 1` `K 4`
+                    else `replace` registers' `K (sz:=1) 1` `K 1` in
+
+           (busy', done', registers', tl_d2h') initially
+           (false, (false, ([0; 1], default (t:=tl_d2h_t))))
+           : denote_type (Bit ** Bit ** Vec (BitVec 32) 2 ** tl_d2h_t)
+        in
+
+        tl_d2h
+       }}.
+End Var.
+
+Definition sim {s i o} (c : Circuit s i o) (input : list (denote_type i))
+  : list (denote_type s * denote_type i * denote_type o) :=
+  fst (List.fold_left (fun '(acc, s) i =>
+                         let '(s', o) := step c s i in
+                         (acc ++ [(s, i, o)], s'))
+                      input
+                      ([], reset_state c)).
+(* Print sample_trace. *)
+
+Example sample_trace :=
+  Eval compute in
+    let nop := set_d_ready true tl_h2d_default in
+    let read_reg (r : N) :=
+        set_a_valid true
+        (set_a_opcode Get
+        (set_a_size 2%N
+        (set_a_address r
+        (set_d_ready true tl_h2d_default)))) in
+    let write_val (v : N) :=
+        set_a_valid true
+        (set_a_opcode PutFullData
+        (set_a_size 2%N
+        (set_a_address 0%N (* value-ref *)
+        (set_a_data v
+        (set_d_ready true tl_h2d_default))))) in
+
+    sim incr
+        [ (nop, tt)
+          ; (read_reg 4, tt) (* status *)
+          ; (nop, tt)
+          ; (write_val 42, tt)
+          ; (nop, tt)
+          ; (nop, tt)
+          ; (read_reg 4, tt) (* status *)
+          ; (nop, tt)
+          ; (read_reg 0, tt) (* value *)
+          ; (nop, tt)
+          ; (read_reg 4, tt) (* status *)
+        ]%N.
+
+Section Spec.
+  Local Open Scope N.
+
+  Variant inner_state :=
+  | IISIdle
+  | IISBusy (data : N) (count : nat)
+  | IISDone (res : N).
+
+  Notation inner_repr := inner_state.
+
+  Global Instance inner_invariant : invariant_for inner inner_repr :=
+    fun (state : denote_type (state_of inner)) repr =>
+      let '(istate, value) := state in
+      match repr with
+      | IISIdle => istate = 0
+      | IISBusy data c => (0 < c <= 2)%nat /\ istate = N.of_nat c /\ value = data
+      | IISDone res => istate = 3 /\ value = res
+      end.
+
+  Definition inner_spec_step (input : denote_type (input_of inner)) repr :=
+    let '(valid, (data, tt)) := input in
+    match repr with
+    | IISIdle => if valid then IISBusy data 1 else IISIdle
+    | IISBusy data 2 => IISDone ((data + 1) mod 2^32)
+    | IISBusy data c => IISBusy data (c + 1)
+    | IISDone _ => IISIdle
+    end.
+
+  Instance inner_specification
+    : specification_for inner inner_repr :=
+    {| reset_repr := IISIdle;
+
+       update_repr :=
+         fun (input : denote_type (input_of inner)) repr =>
+           inner_spec_step input repr;
+
+       precondition :=
+         fun (input : denote_type (input_of inner)) repr => True;
+
+       postcondition :=
+         fun (input : denote_type (input_of inner)) repr
+           (output : denote_type (output_of inner)) =>
+           let repr' := inner_spec_step input repr in
+           match repr' with
+           | IISDone res => output = (true, res)
+           | _ => exists res, output = (false, res)
+           end;
+    |}.
+
+  Lemma inner_invariant_at_reset : invariant_at_reset inner.
+  Proof.
+    simplify_invariant inner. reflexivity.
+  Qed.
+
+  Lemma inner_invariant_preserved : invariant_preserved inner.
+  Proof.
+    intros (valid, (data, t)) state repr. destruct t.
+    cbn in * |-. destruct state as (istate, value).
+    intros repr' ? Hinvar Hprec; subst.
+    simplify_invariant inner.
+    simplify_spec inner.
+    cbv [inner inner_spec_step]. stepsimpl.
+    repeat (destruct_pair_let; cbn [fst snd]).
+    destruct repr as [|? iiscount|?]; logical_simplify; subst.
+    - destruct valid; cbn; try ssplit; lia.
+    - destruct iiscount as [|[|[|iiscount]]]; cbn; ssplit; lia.
+    - reflexivity.
+  Qed.
+
+  Lemma inner_output_correct : output_correct inner.
+  Proof.
+    intros (valid, (data, t)) state repr. destruct t.
+    cbn in * |-. destruct state as (istate, value).
+    remember (update_repr (c:=inner) (valid, (data, tt)) repr) as repr'.
+    intros Hinvar Hprec.
+    simplify_invariant inner.
+    simplify_spec inner.
+    cbv [inner inner_spec_step]. stepsimpl.
+    repeat (destruct_pair_let; cbn [fst snd]).
+    destruct repr as [|? iiscount|?]; logical_simplify; subst.
+    - destruct valid; eexists; cbn; try ssplit; reflexivity.
+    - destruct iiscount as [|[|[|iiscount]]]; try lia; try eexists; reflexivity.
+    - eexists. reflexivity.
+  Qed.
+
+  Existing Instances inner_invariant_at_reset inner_invariant_preserved
+           inner_output_correct.
+  Global Instance inner_correctness : correctness_for inner.
+  Proof. constructor; typeclasses eauto. Defined.
+
+
+  Variant repr_state :=
+  | RSIdle
+  | RSBusy (data : N)
+  | RSDone (res : N).
+
+  Definition repr := (repr_state * list N * list tl_h2d * inner_repr)%type.
+
+  Global Instance incr_invariant : invariant_for incr repr :=
+    fun (state : denote_type (state_of incr)) repr =>
+      let '((s_busy, (s_done, (s_regs, s_d2h))), (s_tlul, s_inner)) := state in
+      let '(r_state, r_regs, r_tlul, r_inner) := repr in
+      tlul_invariant (reg_count:=2) s_tlul r_tlul
+      /\ inner_invariant s_inner r_inner
+      /\ match r_state with
+        | RSIdle => s_busy = false /\ s_done = false
+                   /\ r_inner = IISIdle
+                   /\ nth 1 r_regs 0%N = 1
+        | RSBusy data => s_busy = true /\ s_done = false
+                        /\ (exists c, r_inner = IISBusy data c)
+                        /\ nth 1 r_regs 0%N = 2
+        | RSDone res => s_busy = false /\ s_done = true
+                       /\ (r_inner = IISDone res \/ r_inner = IISIdle)
+                       /\ nth 0 r_regs 0%N = res
+                       /\ nth 1 r_regs 0%N = 4
+        end
+      /\ s_regs = r_regs
+      /\ length r_regs = 2%nat.
+
+  Existing Instance tlul_specification.
+
+  Instance incr_specification
+    : specification_for incr repr :=
+    {| reset_repr := (RSIdle, [0; 1], [], IISIdle);
+
+       update_repr :=
+         fun (input : denote_type (input_of incr)) repr =>
+           let '(i_h2d, tt) := input in
+           let '(r_state, r_regs, r_tlul, r_inner) := repr in
+
+           let h2d := set_a_address (N.land (a_address i_h2d) 4) i_h2d in
+
+           let r_tlul' :=
+               let tlul_input := (h2d, (r_regs, tt)) in
+               update_repr (c:=tlul_adapter_reg (reg_count:=2))
+                           tlul_input r_tlul in
+
+           (* compute (some) tlul output *)
+           let '(is_read, is_write, address, write_data) :=
+               match outstanding_h2d (h2d :: r_tlul) with
+               | None => (false, false, 0, 0)
+               | Some h2d' =>
+                 if a_opcode h2d' =? Get then
+                   match outstanding_h2d r_tlul with
+                   | None => (a_valid h2d, false, a_address h2d, 0)
+                   | _ => (false, false, 0, 0)
+                   end
+                 else if a_opcode h2d' =? PutFullData then
+                   match outstanding_h2d r_tlul with
+                   | None => (false, a_valid h2d, a_address h2d, a_data h2d)
+                   | _ => (false, false, 0, 0)
+                   end
+                 else (false, false, 0, 0)
+               end in
+
+           let r_inner' :=
+               let inner_input := (match r_state with RSIdle => is_write | _ => false end, (write_data, tt)) in
+               update_repr (c:=inner) inner_input r_inner in
+
+           let r_state' :=
+               match r_state with
+               | RSDone _ =>
+                 if negb (is_read && (address =? 0)) then r_state
+                 else RSIdle
+               | _ =>
+                 match r_inner' with
+                 | IISBusy data _ => RSBusy data
+                 | IISDone res => RSDone res
+                 | _ => r_state
+                 end
+               end in
+
+           let r_regs' :=
+               match r_inner' with
+               | IISDone res => replace 0 res r_regs
+               | _ => r_regs
+               end in
+
+           let r_regs' :=
+               match r_state' with
+               | RSIdle => replace 1 1 r_regs'
+               | RSBusy _ => replace 1 2 r_regs'
+               | RSDone _ => replace 1 4 r_regs'
+               end in
+
+           (r_state', r_regs', h2d :: r_tlul, r_inner');
+
+       precondition :=
+         fun (input : denote_type (input_of incr)) repr =>
+           let '(i_h2d, tt) := input in
+           let '(r_state, r_regs, r_tlul, r_inner) := repr in
+
+           let h2d := set_a_address (N.land (a_address i_h2d) 4) i_h2d in
+
+           let tlul_input := (h2d, (r_regs, tt)) in
+
+           let prec_tlul :=
+               precondition (tlul_adapter_reg (reg_count:=2))
+                            tlul_input r_tlul in
+
+           let prec_inner :=
+               forall d2h is_read is_write address write_data write_mask,
+                 postcondition (tlul_adapter_reg (reg_count:=2))
+                               tlul_input r_tlul
+                               (d2h, (is_read, (is_write, (address, (write_data, write_mask)))))
+                 -> precondition inner (match r_state with RSIdle => is_write | _ => false end, (write_data, tt)) r_inner in
+
+           prec_tlul /\ prec_inner;
+
+       postcondition :=
+         fun (input : denote_type (input_of incr)) repr
+           (output : denote_type (output_of incr)) =>
+           let '(i_h2d, tt) := input in
+           let '(r_state, r_regs, r_tlul, r_inner) := repr in
+
+           let h2d := set_a_address (N.land (a_address i_h2d) 4) i_h2d in
+
+           let postc_tlul :=
+               let tlul_input := (h2d, (r_regs, tt)) in
+               exists req,
+                 postcondition (tlul_adapter_reg (reg_count:=2))
+                               tlul_input r_tlul
+                               (output, req) in
+           postc_tlul;
+    |}.
+
+  Lemma incr_invariant_at_reset : invariant_at_reset incr.
+  Proof.
+    simplify_invariant incr.
+    cbn. ssplit; try reflexivity.
+    apply (tlul_adapter_reg_invariant_at_reset (reg_count:=2)).
+  Qed.
+
+  Existing Instance tlul_adapter_reg_correctness.
+
+  Lemma incr_invariant_preserved : invariant_preserved incr.
+  Proof.
+    intros (h2d, t) state (((r_state, r_regs), r_tlul), r_inner). destruct t.
+    cbn in * |-. destruct state as ((busy, (done, (registers, d2h))), (tl_st, inner_st)).
+    destruct_tl_h2d. destruct_tl_d2h.
+    intros repr' ? Hinvar Hprec; subst.
+    simplify_invariant incr. logical_simplify. subst.
+    simplify_spec incr. logical_simplify. subst.
+    (* destruct Hprec as [regs Hprec]. *)
+    cbv [incr]. stepsimpl.
+    use_correctness.
+    match goal with
+    | H: (match outstanding_h2d (_::r_tlul) with | _ => _ end) |- _ =>
+      rename H into Htl_postc
+    end.
+    repeat (destruct_pair_let; cbn [fst snd]).
+    ssplit.
+    - eapply tlul_adapter_reg_invariant_preserved.
+      2: apply H.
+      + reflexivity.
+      + assumption.
+    - eapply inner_invariant_preserved.
+      2: apply H0.
+      + simpl in *.
+        destruct r_inner; try reflexivity.
+        destruct (outstanding_h2d r_tlul) eqn:Houts.
+        * destruct d_ready; logical_simplify; subst.
+          -- boolsimpl. destruct r_state; reflexivity.
+          -- eapply outstanding_prec in H as Hprec_t. 2: apply Houts.
+             destruct Hprec_t as [Hprec_t|Hprec_t];
+               rewrite Hprec_t in *; cbn in Htl_postc |- *; logical_simplify; subst;
+                 boolsimpl; destruct r_state; reflexivity.
+        * destruct a_valid eqn:Hvalid; logical_simplify; subst.
+          -- cbn in Htl_postc.
+             match goal with
+             | H: true = true -> _ |- _ =>
+               destruct H; try reflexivity; subst
+             end; cbn in Htl_postc; logical_simplify; subst;
+               boolsimpl; destruct r_state; logical_simplify; subst;
+                 reflexivity.
+          -- boolsimpl; destruct r_state; reflexivity.
+      + match goal with
+        | H: context [_ -> precondition inner _ r_inner] |- _ =>
+          eapply H
+        end.
+        do 8 eexists. ssplit.
+        1-2: reflexivity.
+        apply Htl_postc.
+    - match goal with
+      | H: context [_ -> precondition inner _ r_inner] |- _ => clear H
+      end.
+      destruct r_inner; destruct r_state; destruct inner_st;
+        unfold inner_invariant in H0; logical_simplify; subst;
+          try discriminate;
+          try (destruct H4; discriminate).
+      all: destruct (outstanding_h2d r_tlul) eqn:Houts;
+        cbn [outstanding_h2d] in Htl_postc |- *; rewrite Houts in Htl_postc |- *.
+      all: tlsimpl; destruct d_ready; logical_simplify; subst; boolsimpl.
+      all: cbn; try (ssplit; try reflexivity;
+                     destruct x0 as [|? [|]]; try discriminate H3; reflexivity).
+      all: try (eapply outstanding_prec in H;
+                try match goal with
+                    | H: outstanding_h2d _ = Some _ |- outstanding_h2d _ = Some _ =>
+                      apply H
+                    end; destruct H; rewrite H in Htl_postc |- *; cbn in Htl_postc |- *;
+                logical_simplify; subst; ssplit;
+                try (left; reflexivity);
+                try (right; reflexivity);
+                try reflexivity;
+                destruct x0 as [|? [|]]; try discriminate H3; reflexivity).
+      all: try (destruct a_valid; simplify_spec (tlul_adapter_reg (reg_count:=2));
+                   logical_simplify; tlsimpl;
+                try match goal with
+                    | H: true = true -> _ |- _ =>
+                      destruct H; try reflexivity; subst
+                    end; try cbn in Htl_postc; logical_simplify; subst; cbn; ssplit;
+                try eexists;
+                try reflexivity;
+                destruct x0 as [|? [|]]; try discriminate H3; reflexivity).
+      all: try (destruct a_valid; ssplit;
+                try (left; reflexivity);
+                try (right; reflexivity);
+                try reflexivity;
+                destruct x0 as [|? [|]]; try discriminate H3; reflexivity).
+      all: try (destruct a_valid; simplify_spec (tlul_adapter_reg (reg_count:=2));
+                tlsimpl; logical_simplify;
+                try match goal with
+                    | H: true = true -> _ |- _ =>
+                      destruct H; try reflexivity; subst
+                    end; try cbn in Htl_postc; logical_simplify; subst;
+                boolsimpl; destruct (negb (N.land a_address 4 =? 0)) eqn:Haddr;
+                cbn; try (rewrite Haddr); ssplit;
+                try (left; reflexivity);
+                try (right; reflexivity);
+                try reflexivity;
+                destruct x0 as [|? [|]]; try discriminate H3; reflexivity).
+      all: try (inversion H5; subst; clear H5;
+            destruct x as [|[|[|?]]]; cbn; ssplit;
+            try eexists;
+            try (left; reflexivity);
+            try (right; reflexivity);
+            try reflexivity;
+            try (destruct x0 as [|? [|]]; try discriminate H3; reflexivity);
+            exfalso; lia).
+      all: destruct H5; discriminate.
+    - match goal with
+      | H: context [_ -> precondition inner _ r_inner] |- _ => clear H
+      end.
+      destruct r_inner; destruct r_state; destruct inner_st;
+        unfold inner_invariant in H0; logical_simplify; subst;
+          try discriminate.
+      all: destruct (outstanding_h2d r_tlul) eqn:Houts;
+        cbn [outstanding_h2d] in Htl_postc |- *; rewrite Houts in Htl_postc |- *.
+      all: tlsimpl; destruct d_ready; logical_simplify; subst; boolsimpl.
+      all: try reflexivity.
+      all: try (destruct H5; discriminate).
+      all: try (inversion H5; subst; clear H5;
+            destruct x as [|[|[|?]]]; try reflexivity; exfalso; lia).
+      all: try (eapply outstanding_prec in H;
+                try match goal with
+                    | H: outstanding_h2d _ = Some _ |- outstanding_h2d _ = Some _ =>
+                      apply H
+                    end; destruct H; rewrite H in Htl_postc |- *; cbn in Htl_postc |- *;
+                logical_simplify; subst; cbn; reflexivity).
+      all: try (destruct a_valid; simplify_spec (tlul_adapter_reg (reg_count:=2));
+                tlsimpl; logical_simplify;
+                try match goal with
+                    | H: true = true -> _ |- _ =>
+                      destruct H; try reflexivity; subst
+                    end; try cbn in Htl_postc; logical_simplify; subst; reflexivity).
+      all: try (destruct a_valid; simplify_spec (tlul_adapter_reg (reg_count:=2));
+                tlsimpl; logical_simplify;
+                try match goal with
+                    | H: true = true -> _ |- _ =>
+                      destruct H; try reflexivity; subst
+                    end; try cbn in Htl_postc; logical_simplify; subst;
+                boolsimpl; destruct (negb (N.land a_address 4 =? 0)) eqn:Haddr;
+                cbn; try (rewrite Haddr); reflexivity).
+    - all: match goal with
+           | |- length (match ?v with _ => _ end) = 2%nat => destruct v
+           end;
+        match goal with
+        | |- context [update_repr ?ui ?ur] =>
+          remember (update_repr (c:=inner) ui ur) as up eqn:?H;
+            replace (update_repr (c:=inner) ui ur) with up;
+            destruct up
+        end;
+        rewrite ! length_replace; assumption.
+  Qed.
+
+  Lemma incr_output_correct : output_correct incr.
+  Proof.
+    intros (h2d, t) state (((r_state, r_regs), r_tlul), r_inner). destruct t.
+    cbn in * |-. destruct state as ((busy, (done, (registers, d2h))), (tl_st, inner_st)).
+    destruct_tl_h2d. destruct_tl_d2h.
+    intros Hinvar Hprec; subst.
+    simplify_invariant incr. logical_simplify. subst.
+    simplify_spec incr. logical_simplify. subst.
+    cbv [incr]. stepsimpl.
+    use_correctness.
+    match goal with
+    | H: (match outstanding_h2d (_::r_tlul) with | _ => _ end) |- _ =>
+      rename H into Htl_postc
+    end.
+    repeat (destruct_pair_let; cbn [fst snd]).
+    tlsimpl.
+    destruct r_inner; destruct r_state; destruct inner_st;
+      unfold inner_invariant in H0; logical_simplify; subst;
+        try discriminate;
+        try (destruct H5; discriminate).
+    all: destruct (outstanding_h2d r_tlul) eqn:Houts;
+      cbn [outstanding_h2d] in Htl_postc |- *; rewrite Houts in Htl_postc |- *.
+    all: tlsimpl; destruct d_ready; logical_simplify; subst; boolsimpl.
+    all: do 9 eexists.
+    all: ssplit; try reflexivity; tlsimpl; ssplit; try reflexivity; try assumption.
+    all: try (eapply outstanding_prec in H;
+              try match goal with
+                  | H: outstanding_h2d _ = Some _ |- outstanding_h2d _ = Some _ =>
+                    apply H
+                  end; destruct H; rewrite H in Htl_postc |- *; cbn in Htl_postc |- *;
+              logical_simplify; subst; ssplit;
+              try (left; reflexivity);
+              try (right; reflexivity);
+              try assumption;
+              reflexivity).
+    all: try (destruct a_valid; simplify_spec (tlul_adapter_reg (reg_count:=2));
+              tlsimpl; destruct H2;
+              try match goal with
+                  | H: true = true -> _ |- _ =>
+                    destruct H; try reflexivity; subst
+                  end; cbn in Htl_postc; logical_simplify; subst; cbn; ssplit;
+              try eexists; try assumption; reflexivity).
+    Unshelve. all: auto.
+  Qed.
+
+  Existing Instances incr_invariant_at_reset incr_invariant_preserved
+           incr_output_correct.
+  Global Instance incr_correctness : correctness_for incr.
+  Proof. constructor; typeclasses eauto. Defined.
+End Spec.

--- a/firmware/IncrementWait/RunIncrementWaitSoftwareOnCava.v
+++ b/firmware/IncrementWait/RunIncrementWaitSoftwareOnCava.v
@@ -90,14 +90,16 @@ Section WithVar.
     end%list.
 
   (* Useful for debugging: display (ok-flag, pc, output) after each cycle:
+     TODO why are some flags false, but then again true??
   Compute snd (trace 100 initial).
   *)
 
   Definition res(nsteps: nat): LogElem := outcomeToLogElem (run_rec sched 0 nsteps initial).
 
   (* We can vm_compute through the execution of the IncrementWait program,
-     riscv-coq's processor model, and Cava's reaction to the IncrementWait program: *)
+     riscv-coq's processor model, and Cava's reaction to the IncrementWait program:
   Goal exists nsteps, res nsteps = (true, word.unsigned ret_addr, 43).
     exists 55%nat. vm_compute. reflexivity.
   Qed.
+  *)
 End WithVar.

--- a/firmware/IncrementWait/RunIncrementWaitSoftwareOnCava.v
+++ b/firmware/IncrementWait/RunIncrementWaitSoftwareOnCava.v
@@ -4,6 +4,7 @@ Require Import coqutil.Datatypes.List.
 Require Import coqutil.Word.Interface coqutil.Map.Interface.
 Require Import coqutil.Map.OfListWord.
 Require Import Bedrock2Experiments.RiscvMachineWithCavaDevice.InternalMMIOMachine.
+Require Import Bedrock2Experiments.IncrementWait.Incr.
 Require Import Bedrock2Experiments.IncrementWait.IncrementWaitToRiscV.
 Require Import Bedrock2Experiments.IncrementWait.CavaIncrementDevice.
 Require Import riscv.Spec.Decode.

--- a/firmware/RiscvMachineWithCavaDevice/InternalMMIOMachine.v
+++ b/firmware/RiscvMachineWithCavaDevice/InternalMMIOMachine.v
@@ -91,7 +91,7 @@ Module device.
   Definition waitForResp{D: device} :=
     fix rec(fuel: nat)(s: device.state): option tl_d2h * device.state :=
       let next := device.run1 s (set_d_ready true tl_h2d_default) in
-      if d_valid (device.last_d2h s) then (Some (device.last_d2h s), next)
+      if d_valid (device.last_d2h next) then (Some (device.last_d2h next), next)
       else
         match fuel with
         | O => (None, s)
@@ -104,8 +104,8 @@ Module device.
     fix rec(fuel: nat)(s: device.state): option tl_d2h * device.state :=
       let next := device.run1 s h2d in
       if a_ready (device.last_d2h s) then
-        if d_valid (device.last_d2h s) then
-          (Some (device.last_d2h s), next)
+        if d_valid (device.last_d2h next) then
+          (Some (device.last_d2h next), next)
         else
           match fuel with
           | O => (None, s)
@@ -270,7 +270,7 @@ Section WithParams.
     end.
 
   Definition device_step_without_IO(d: D): D :=
-    let next_state := (device.run1 d tl_h2d_default) in next_state.
+    let next_state := device.run1 d (set_d_ready true tl_h2d_default) in next_state.
 
   Fixpoint device_steps(n: nat): OState (ExtraRiscvMachine D) unit :=
     match n with

--- a/firmware/RiscvMachineWithCavaDevice/InternalMMIOMachine.v
+++ b/firmware/RiscvMachineWithCavaDevice/InternalMMIOMachine.v
@@ -59,12 +59,6 @@ Module device.
      [forall s h2d d2h s', run1 s h2d = (s', d2h) -> last_d2h s' = d2h] *)
     last_d2h: state -> tl_d2h;
 
-    (* indicates an inflight operation: the device received a request on channel
-       A, but a response on channel D hasn't been exchanged yet *)
-    (* TODO: probably need to add to [device_implements_state_machine] somthing like
-     [forall s, is_ready_state s -> tl_inflight_ops s = []] *)
-    tl_inflight_ops: state -> list N;
-
     (* run one simulation step, will be instantiated with Cava.Semantics.Combinational.step *)
     run1: (* input: TileLink host-2-device *)
       state -> tl_h2d ->

--- a/firmware/RiscvMachineWithCavaDevice/InternalMMIOMachine.v
+++ b/firmware/RiscvMachineWithCavaDevice/InternalMMIOMachine.v
@@ -79,7 +79,7 @@ Module device.
 
     (* max number of device cycles this device takes to serve read/write requests, ie
        max number of run1 calls with active read/write request until the device responds *)
-    maxRespDelay: state -> tl_h2d -> nat;
+    maxRespDelay: state -> nat;
   }.
   (* Note: there are two levels of "polling until a response is available":
      - on the hardware level, using runUntilResp, which appears as
@@ -177,7 +177,7 @@ Section WithParams.
     OState (ExtraRiscvMachine D) word :=
     mach <- get;
     let (respo, new_device_state) :=
-        device.runUntilResp h2d (device.maxRespDelay mach.(getExtraState) h2d)
+        device.runUntilResp h2d (device.maxRespDelay mach.(getExtraState))
                             mach.(getExtraState) in
     put (withExtraState new_device_state mach);;
     resp <- fail_if_None respo;

--- a/silveroak-opentitan/hmac/end2end/Bedrock2StateMachineToCavaHmac.v
+++ b/silveroak-opentitan/hmac/end2end/Bedrock2StateMachineToCavaHmac.v
@@ -1,0 +1,221 @@
+(****************************************************************************)
+(* Copyright 2021 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+Require Import Coq.Arith.PeanoNat.
+Require Import Coq.micromega.Lia.
+Require Import Coq.Lists.List.
+Require Import Coq.ZArith.ZArith.
+
+Require Import coqutil.Tactics.Tactics.
+Require Import coqutil.Datatypes.Prod.
+
+Require Import Cava.Util.Byte.
+Require Import Cava.Types.
+Require Import Cava.Expr.
+Require Import Cava.Primitives.
+Require Import Cava.TLUL.
+Require Import Cava.Invariant.
+Require Import Cava.Primitives.
+Require Import Cava.Semantics.
+Require Import Cava.Expr.
+Require Import Cava.ExprProperties.
+Require Import Cava.Util.Tactics.
+Require Import Cava.Util.List.
+Require Import Cava.Util.If.
+Require Import Cava.Util.Nat.
+Require Import Cava.Util.Byte.
+Require Import coqutil.Word.Interface coqutil.Word.Properties.
+Require Import coqutil.Word.LittleEndianList.
+Require Import HmacHardware.Hmac.
+Require Import HmacHardware.Sha256.
+Require HmacSoftware.HmacSemantics.
+
+Import ListNotations.
+
+Axiom hmac_repr: Type.
+(* Note: hmac_repr might/should be an Inductive, so probably no hmac_repr_msg getter will
+   exists, but we will need to do a match, and assert False in the other cases *)
+Axiom hmac_repr_msg: hmac_repr -> list Byte.byte.
+Axiom hmac_repr_max_cycles_until_done: hmac_repr -> nat.
+
+Instance hmac_invariant: invariant_for hmac hmac_repr. Admitted.
+
+(* TLUL communication state *)
+Inductive tlul_protocol_state :=
+(* host is not interested in talking to device at the moment *)
+| HostNotInterested
+(* host wants to talk to device and is waiting for device to become ready *)
+| HostWaitingForReady(maxDelay: nat)
+(* host can and will send a packet in the next cycle *)
+| HostCanSend
+(* host sent a message to device and is waiting for a reply from device *)
+| HostWaitingForReply(packet: tl_h2d)(maxDelay: nat).
+
+Definition tlul_state_step(s1 s2: tlul_protocol_state): Prop :=
+  match s1 with
+  | HostNotInterested =>
+    s2 = HostNotInterested \/
+    exists maxDelay, s2 = HostWaitingForReady maxDelay
+  | HostWaitingForReady maxDelay =>
+    (exists maxDelay', maxDelay = S maxDelay' /\ s2 = HostWaitingForReady maxDelay') \/
+    s2 = HostCanSend
+  | HostCanSend => exists packet maxDelay, s2 = HostWaitingForReply packet maxDelay
+  | HostWaitingForReply packet maxDelay =>
+    (exists maxDelay', maxDelay = S maxDelay' /\ s2 = HostWaitingForReply packet maxDelay') \/
+    s2 = HostNotInterested
+  end.
+
+Definition a_valid_of_current_tlul_state(s: tlul_protocol_state): bool :=
+  match s with
+  | HostNotInterested => false
+  | HostWaitingForReady maxDelay => false
+  | HostCanSend => true
+  | HostWaitingForReply packet maxDelay => false
+  end.
+
+Definition d_ready_of_current_tlul_state(s: tlul_protocol_state): bool :=
+  match s with
+  | HostNotInterested => false
+  | HostWaitingForReady maxDelay => false
+  | HostCanSend => true
+  | HostWaitingForReply packet maxDelay => true
+  end.
+
+Definition d_valid_of_current_and_next_tlul_state(s1 s2: tlul_protocol_state): bool :=
+  match s1 with
+  | HostWaitingForReply packet maxDelay =>
+    match s2 with
+    | HostWaitingForReply packet' maxDelay' => false
+    | _ => true
+    end
+  | _ => false
+  end.
+
+(* If the host and device both behave correctly, then each device cycle that takes in
+   h2d and outputs d2h (ie `step circuit circuit_state1 h2d = (circuit_state2, d2h)`)
+   corresponds to a transition in the following transition system: *)
+Definition tlul_step(s1: tlul_protocol_state)(h2d: tl_h2d)
+                    (s2: tlul_protocol_state)(d2h: tl_d2h): Prop :=
+  a_valid h2d = a_valid_of_current_tlul_state s1 /\
+  d_ready h2d = d_ready_of_current_tlul_state s1 /\
+  d_valid d2h = d_valid_of_current_and_next_tlul_state s1 s2 /\
+  match s1 with
+  | HostNotInterested =>
+    match s2 with
+    | HostNotInterested => True
+    | HostWaitingForReady maxDelay => a_ready d2h = false
+    | HostCanSend => a_ready d2h = true
+    | HostWaitingForReply packet maxDelay => False
+    end
+  | HostWaitingForReady maxDelay =>
+    match s2 with
+    | HostNotInterested => False
+    | HostWaitingForReady maxDelay' => a_ready d2h = false /\ maxDelay = S maxDelay'
+    | HostCanSend => a_ready d2h = true
+    | HostWaitingForReply packet maxDelay => False
+    end
+  | HostCanSend =>
+    match s2 with
+    | HostWaitingForReply packet maxDelay => packet = h2d
+    | _ => False
+    end
+  | HostWaitingForReply packet maxDelay =>
+    match s2 with
+    | HostNotInterested => True
+    | HostWaitingForReady maxDelay' => a_ready d2h = false
+    | HostCanSend => a_ready d2h = true
+    | HostWaitingForReply packet' maxDelay' => packet' = packet /\ maxDelay = S maxDelay'
+    end
+  end.
+
+Section WithParams.
+  Context {word: word 32} {word_ok: word.ok word}.
+
+  Definition REG_DIGEST_0: nat.
+    let r := eval unfold HmacHardware.Hmac.REG_DIGEST_0 in HmacHardware.Hmac.REG_DIGEST_0 in
+    lazymatch r with
+    | Constant _ ?v => exact (N.to_nat v)
+    end.
+  Defined.
+
+  Definition REG_CFG: nat.
+    let r := eval unfold HmacHardware.Hmac.REG_CFG in HmacHardware.Hmac.REG_CFG in
+    lazymatch r with
+    | Constant _ ?v => exact (N.to_nat v)
+    end.
+  Defined.
+
+  Definition REG_INTR_STATE: nat := 0.
+  Definition REG_INTR_ENABLE: nat := 1.
+
+  Definition N_le_word_list_to_byte_list: list N -> list Byte.byte :=
+    List.flat_map (fun n => le_split 4 (Z.of_N n)).
+
+  Definition get_hl_config(regs: list N): HmacSemantics.idle_data := {|
+    HmacSemantics.intr_enable := word.of_Z (Z.of_N (List.nth REG_INTR_ENABLE regs 0%N));
+    HmacSemantics.hmac_done := N.testbit 0 (List.nth REG_INTR_ENABLE regs 0%N);
+    HmacSemantics.hmac_en := N.testbit 0 (List.nth REG_CFG regs 0%N);
+    HmacSemantics.sha_en := N.testbit 1 (List.nth REG_CFG regs 0%N);
+    HmacSemantics.swap_endian := N.testbit 2 (List.nth REG_CFG regs 0%N);
+    HmacSemantics.swap_digest := N.testbit 3 (List.nth REG_CFG regs 0%N);
+  |}.
+
+  Instance hmac_top_invariant: invariant_for hmac_top HmacSemantics.state :=
+    fun (circuit_state: denote_type hmac_top_state) (stm_state: HmacSemantics.state) =>
+      let '((wasfull, (d2h, regs)), (tlul_st, hmac_st)) := circuit_state in
+      exists hmac_r: hmac_repr, hmac_invariant hmac_st hmac_r /\
+      match stm_state with
+      | HmacSemantics.IDLE digest config =>
+        digest = N_le_word_list_to_byte_list (List.firstn 8 (List.skipn REG_DIGEST_0 regs)) /\
+        config = get_hl_config regs
+      | HmacSemantics.CONSUMING buf =>
+        get_hl_config regs = HmacSemantics.sha_default_cfg /\
+        hmac_repr_msg hmac_r = buf
+      | HmacSemantics.PROCESSING buf ncycles =>
+        get_hl_config regs = HmacSemantics.sha_default_cfg /\
+        hmac_repr_msg hmac_r = buf /\
+        Z.of_nat (hmac_repr_max_cycles_until_done hmac_r) = ncycles
+      end.
+
+  Instance hmac_top_specification: specification_for hmac_top HmacSemantics.state := {|
+    reset_repr := HmacSemantics.IDLE (List.repeat Byte.x00 32) HmacSemantics.zero_cfg;
+    precondition h2d st := True;
+    update_repr h2d st :=
+      match st with
+      | HmacSemantics.IDLE digest config => st
+      | HmacSemantics.CONSUMING buf => st
+      | HmacSemantics.PROCESSING buf ncycles => st
+      end;
+    postcondition h2d st d2h := True;
+  |}.
+
+  Lemma hmac_top_invariant_at_reset: invariant_at_reset hmac_top.
+  Admitted.
+
+  Lemma hmac_top_invariant_preserved: invariant_preserved hmac_top.
+  Proof.
+    simplify_invariant hmac_top. cbn [absorb_any].
+    simplify_spec hmac_top.
+    intros input state repr new_repr.
+  Admitted.
+
+  Lemma hmac_top_output_correct: output_correct hmac_top.
+  Proof.
+    simplify_invariant hmac_top. simplify_spec hmac_top.
+    intros input state repr new_repr.
+  Admitted.
+
+End WithParams.

--- a/silveroak-opentitan/hmac/end2end/CavaHmacDevice.v
+++ b/silveroak-opentitan/hmac/end2end/CavaHmacDevice.v
@@ -1,3 +1,4 @@
+Require Import Coq.Lists.List.
 Require Import Coq.ZArith.ZArith. Open Scope Z_scope.
 Require Import riscv.Utility.Utility.
 Require Import coqutil.Map.Interface coqutil.Map.Properties.
@@ -16,6 +17,7 @@ Require Import Cava.TLUL.
 Require Import Cava.Types.
 Require Import Cava.Util.BitArithmetic.
 
+Import ListNotations.
 
 Section WithParameters.
   Instance var : tvar := denote_type.
@@ -28,12 +30,21 @@ Section WithParameters.
   Global Instance hmac_device: device := {|
     device.state := denote_type (state_of hmac_top);
     device.is_ready_state s := True; (* FIXME *)
-    device.run1 s i := Semantics.step hmac_top s (i, tt);
+
+    device.last_d2h '((_, (d2h, _)), _) := d2h;
+
+    device.tl_inflight_ops '((_, (d2h, _)), _) :=
+      if d_valid d2h then [d_source d2h] else [];
+
+    device.run1 s i := fst (Semantics.step hmac_top s (i, tt));
+
     device.addr_range_start := TOP_EARLGREY_HMAC_BASE_ADDR;
     device.addr_range_pastend := TOP_EARLGREY_HMAC_BASE_ADDR +
                                  HMAC_MSG_FIFO_REG_OFFSET +
                                  HMAC_MSG_FIFO_SIZE_BYTES;
-    device.maxRespDelay := 1; (* FIXME *)
+
+    device.maxRespDelay '((_, (d2h, _)), _) :=
+      if a_ready d2h then 0%nat else 1%nat;
   |}.
   Global Instance hmac_timing: timing := {
     max_negative_done_polls := 16;

--- a/silveroak-opentitan/hmac/end2end/CavaHmacDevice.v
+++ b/silveroak-opentitan/hmac/end2end/CavaHmacDevice.v
@@ -33,9 +33,6 @@ Section WithParameters.
 
     device.last_d2h '((_, (d2h, _)), _) := d2h;
 
-    device.tl_inflight_ops '((_, (d2h, _)), _) :=
-      if d_valid d2h then [d_source d2h] else [];
-
     device.run1 s i := fst (Semantics.step hmac_top s (i, tt));
 
     device.addr_range_start := TOP_EARLGREY_HMAC_BASE_ADDR;

--- a/silveroak-opentitan/hmac/end2end/Sha256ToCava.v
+++ b/silveroak-opentitan/hmac/end2end/Sha256ToCava.v
@@ -42,8 +42,6 @@ Notation ShaDevice := hmac_device.
 (* Trying to keep toplevel theorem at 53 chars wide:
 01234567890123456789012345678901234567890123456789012 *)
 
-Axiom sha256_len: forall inp, List.length (sha256 inp) = 32%nat.
-
 Theorem sha256_end2end_correct:
 forall a_outp a_inp len sp_val a_ret a_code stack_lo
   (inp: list byte) (Rdata Rexec: mem->Prop)


### PR DESCRIPTION
This is a proper implementation of runUtilResp, without trying to fix the proofs.

Note that the first thing the function does is to send an empty h2d packet. A real machine will probably keep track, globally, of the a_ready value from the last d2h packet, and it will use that information instead of sending an empty packet here. This seems to me like we are cheating.

Also note that the process has 2 phases (+ the initial empty packet), and this is not mirrored in the proofs (e.g. in state_machine_read_to_device_read), which breaks them. Moreover, notice that each phase calls run1 with a different input, and not just passing the same h2d multiple times as before, this also needs to be mirrored somewhere.